### PR TITLE
implement different retry logic for terraform destroy 

### DIFF
--- a/.ado/pipelines/templates/steps-terraform-destroy.yaml
+++ b/.ado/pipelines/templates/steps-terraform-destroy.yaml
@@ -27,14 +27,15 @@ steps:
       # To have access to the input ARM_CLIENT_SECRET which was marked as secret, we need to explicitly reference it in the script
       $Env:ARM_CLIENT_SECRET="$(ARM_CLIENT_SECRET)"
 
-      $retrycount = 0
-      $maxretrycount = ${{ parameters.retryCount }}
-      $retrydelay = ${{ parameters.retryDelayInSeconds }}
+      $retrycount = 0 # initialize retry count (set to 0)
+      $maxretrycount = ${{ parameters.retryCount }} # max. number of retries
+      $retrydelay = ${{ parameters.retryDelayInSeconds }} # delay before each retry operation
+      $varfile = "variables-$environment.tfvars" # construct terraform variables file name
 
       do {
         Write-Host "*** Terraform destroy ($retrycount / $maxretrycount)"
         try {
-          terraform destroy -auto-approve -input=false -parallelism=20 -var-file="variables-$(environment).tfvars" ${{ parameters.customAttributes }}
+          terraform destroy -auto-approve -input=false -parallelism=20 -var-file=$varfile ${{ parameters.customAttributes }}
           $isSuccess = $true
         } catch {
           Write-Host "*** Terraform destroy failed. Retrying in $retrydelay seconds."


### PR DESCRIPTION
The new builtin `retryCountOnTaskFailure` argument does not help us here. You cannot configure the delay between two retries and the task/agent is not aware if it's the first or a retry run. Replacing it with some bash magic.

E2E validation:

* AO runs here: https://dev.azure.com/alwaysonapp/AlwaysOn/_build/results?buildId=3614&view=results
* AOF runs here: https://dev.azure.com/alwayson/Foundational/_build/results?buildId=169&view=results

https://github.com/Azure/AlwaysOn/pull/960