### PR TITLE
Add polling file watcher

### DIFF
--- a/src/app/charts/backgroundprocessor/templates/deployment.yaml
+++ b/src/app/charts/backgroundprocessor/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
               value: "30"
             - name: DOCKER_HEALTHCHECK_FILEPATH
               value: "/tmp/healthy"
-            - name: "DOTNET_USE_POLLING_FILE_WATCHER" # Docker is not sending file change notification reliably, this enables file system polling every 4 seconds (not configurable) and thus automatic configuration refresh
+            - name: "DOTNET_USE_POLLING_FILE_WATCHER" # Enables file system polling every 4 seconds (not configurable) when watching for configuration changes. CSI driver automatically updates secrets as files, but Docker is not sending file change notifications reliably
               value: "true"
         volumeMounts:
           - name: secrets-store-inline

--- a/src/app/charts/backgroundprocessor/templates/deployment.yaml
+++ b/src/app/charts/backgroundprocessor/templates/deployment.yaml
@@ -51,6 +51,8 @@ spec:
               value: "30"
             - name: DOCKER_HEALTHCHECK_FILEPATH
               value: "/tmp/healthy"
+            - name: "DOTNET_USE_POLLING_FILE_WATCHER" # Docker is not sending file change notification reliably, this enables file system polling every 4 seconds (not configurable) and thus automatic configuration refresh
+              value: "true"
         volumeMounts:
           - name: secrets-store-inline
             mountPath: "/mnt/secrets-store"

--- a/src/app/charts/catalogservice/templates/deployment.yaml
+++ b/src/app/charts/catalogservice/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
               value: {{ .Values.azure.region }}
             - name: "ASPNETCORE_URLS" # Port used to start the ASP.NET Core application
               value: "http://+:{{ .Values.workload.port | default 8080 }}"
-            - name: "DOTNET_USE_POLLING_FILE_WATCHER" # Docker is not sending file change notification reliably, this enables file system polling every 4 seconds (not configurable) and thus automatic configuration refresh
+            - name: "DOTNET_USE_POLLING_FILE_WATCHER" # Enables file system polling every 4 seconds (not configurable) when watching for configuration changes. CSI driver automatically updates secrets as files, but Docker is not sending file change notifications reliably
               value: "true"
         volumeMounts:
           - name: secrets-store-inline

--- a/src/app/charts/catalogservice/templates/deployment.yaml
+++ b/src/app/charts/catalogservice/templates/deployment.yaml
@@ -53,6 +53,8 @@ spec:
               value: {{ .Values.azure.region }}
             - name: "ASPNETCORE_URLS" # Port used to start the ASP.NET Core application
               value: "http://+:{{ .Values.workload.port | default 8080 }}"
+            - name: "DOTNET_USE_POLLING_FILE_WATCHER" # Docker is not sending file change notification reliably, this enables file system polling every 4 seconds (not configurable) and thus automatic configuration refresh
+              value: "true"
         volumeMounts:
           - name: secrets-store-inline
             mountPath: "/mnt/secrets-store"

--- a/src/app/charts/healthservice/templates/deployment.yaml
+++ b/src/app/charts/healthservice/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               value: {{ .Values.azure.region }}
             - name: "ASPNETCORE_URLS" # Port used to start the ASP.NET Core application
               value: "http://+:{{ .Values.workload.port | default 8080 }}"
-            - name: "DOTNET_USE_POLLING_FILE_WATCHER" # Docker is not sending file change notification reliably, this enables file system polling every 4 seconds (not configurable) and thus automatic configuration refresh
+            - name: "DOTNET_USE_POLLING_FILE_WATCHER" # Enables file system polling every 4 seconds (not configurable) when watching for configuration changes. CSI driver automatically updates secrets as files, but Docker is not sending file change notifications reliably
               value: "true"
         volumeMounts:
           - name: secrets-store-inline

--- a/src/app/charts/healthservice/templates/deployment.yaml
+++ b/src/app/charts/healthservice/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
               value: {{ .Values.azure.region }}
             - name: "ASPNETCORE_URLS" # Port used to start the ASP.NET Core application
               value: "http://+:{{ .Values.workload.port | default 8080 }}"
+            - name: "DOTNET_USE_POLLING_FILE_WATCHER" # Docker is not sending file change notification reliably, this enables file system polling every 4 seconds (not configurable) and thus automatic configuration refresh
+              value: "true"
         volumeMounts:
           - name: secrets-store-inline
             mountPath: "/mnt/secrets-store"


### PR DESCRIPTION
Although the AKS CSI driver did a good job refreshing secrets from Key Vault, our .NET applications were not reloading it automatically. This PR fixes that by adding `DOTNET_USE_POLLING_FILE_WATCHER` environmental variable.

> Some file systems, such as Docker containers and network shares, may not reliably send change notifications. Set the DOTNET_USE_POLLING_FILE_WATCHER environment variable to 1 or true to poll the file system for changes every four seconds (not configurable).

https://docs.microsoft.com/en-us/aspnet/core/fundamentals/file-providers?view=aspnetcore-6.0#watch-for-changes