### PR TITLE
Allow deletion of non-empty per-stamp resource groups

### DIFF
--- a/src/infra/workload/releaseunit/main.tf
+++ b/src/infra/workload/releaseunit/main.tf
@@ -10,7 +10,13 @@ terraform {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      # Allows the deletion of non-empty resource groups
+      # This is required to delete rgs with stale resources left
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 # Random API key which needs to be identical between all stamps


### PR DESCRIPTION
This PR enables the deletion of non-empty resource groups. This is required as sometimes stale resources (like NICs for PEs) remain in resource groups during deletion.