### PR TITLE
Task retries and ingress timeout

### DIFF
--- a/.ado/pipelines/templates/jobs-configuration.yaml
+++ b/.ado/pipelines/templates/jobs-configuration.yaml
@@ -14,6 +14,7 @@ jobs:
 
   - task: AzureCLI@2
     displayName: 'Install ingress-nginx $(ingressNginxVersion) on AKS clusters'
+    retryCountOnTaskFailure: 1
     inputs:
       azureSubscription: $(azureServiceConnection)
       scriptType: pscore
@@ -54,6 +55,7 @@ jobs:
 
   - task: AzureCLI@2
     displayName: 'Configure OMSAgent (Container Insights) on AKS clusters'
+    retryCountOnTaskFailure: 1
     inputs:
       azureSubscription: $(azureServiceConnection)
       scriptType: pscore
@@ -80,6 +82,7 @@ jobs:
 
   - task: AzureCLI@2
     displayName: 'Install cert-manager $(certManagerVersion) on AKS clusters'
+    retryCountOnTaskFailure: 1
     inputs:
       azureSubscription: $(azureServiceConnection)
       scriptType: pscore
@@ -118,6 +121,7 @@ jobs:
 
   - task: AzureCLI@2
     displayName: 'Install KeyVault CSI driver on AKS clusters'
+    retryCountOnTaskFailure: 1
     inputs:
       azureSubscription: $(azureServiceConnection)
       scriptType: pscore
@@ -169,6 +173,7 @@ jobs:
   - ${{ if eq(parameters.runChaosTesting, 'true') }}:
     - task: AzureCLI@2
       displayName: "Install Chaos Mesh $(chaosMeshVersion) on AKS clusters"
+      retryCountOnTaskFailure: 1
       inputs:
         azureSubscription: $(azureServiceConnection)
         scriptType: pscore

--- a/.ado/pipelines/templates/jobs-container-build.yaml
+++ b/.ado/pipelines/templates/jobs-container-build.yaml
@@ -13,6 +13,7 @@ jobs:
 
   - task: AzureCLI@2
     displayName: 'Docker build and push ${{ parameters.containerImageName }}'
+    retryCountOnTaskFailure: 1
     inputs:
       azureSubscription: $(azureServiceConnection)
       scriptType: pscore

--- a/.ado/pipelines/templates/jobs-init-sampledata.yaml
+++ b/.ado/pipelines/templates/jobs-init-sampledata.yaml
@@ -11,6 +11,7 @@ jobs:
 
     - task: PowerShell@2
       displayName: 'Import sample data'
+      retryCountOnTaskFailure: 1
       inputs:
         targetType: inline
         script: |

--- a/.ado/pipelines/templates/jobs-smoke-testing.yaml
+++ b/.ado/pipelines/templates/jobs-smoke-testing.yaml
@@ -13,6 +13,7 @@ jobs:
 
     - task: PowerShell@2
       displayName: 'Verify individual stamp endpoints'
+      retryCountOnTaskFailure: 1
       inputs:
         targetType: 'filePath'
         filePath: $(System.DefaultWorkingDirectory)/.ado/scripts/SmokeTest.ps1
@@ -30,6 +31,7 @@ jobs:
 
     - task: AzureCLI@2
       displayName: 'Verify global Front Foor state configuration'
+      retryCountOnTaskFailure: 1
       inputs:
         azureSubscription: $(azureServiceConnection)
         scriptType: pscore
@@ -53,6 +55,7 @@ jobs:
 
     - task: PowerShell@2
       displayName: 'Verify global Front Door endpoint'
+      retryCountOnTaskFailure: 1
       inputs:
         targetType: 'filePath'
         filePath: $(System.DefaultWorkingDirectory)/.ado/scripts/SmokeTest.ps1
@@ -68,6 +71,7 @@ jobs:
 
     - task: PowerShell@2
       displayName: 'Run PlayWright UI test and capture screenshots from global endpoint'
+      retryCountOnTaskFailure: 1
       inputs:
         targetType: inline
         script: |

--- a/.ado/pipelines/templates/jobs-ui-app-build.yaml
+++ b/.ado/pipelines/templates/jobs-ui-app-build.yaml
@@ -15,12 +15,14 @@ jobs:
 
   - task: Npm@1
     displayName: 'NPM install'
+    retryCountOnTaskFailure: 1
     inputs:
       command: 'install'
       workingDir: ${{ parameters.workingDirectory }}
 
   - task: Npm@1
     displayName: 'Build the static UI app for deployment'
+    retryCountOnTaskFailure: 1
     inputs:
       command: 'custom'
       customCommand: 'run build'
@@ -31,4 +33,3 @@ jobs:
     inputs:
       targetPath: '${{ parameters.workingDirectory }}/dist'
       artifactName: 'uiApp'
-  

--- a/.ado/pipelines/templates/jobs-workload-deploy.yaml
+++ b/.ado/pipelines/templates/jobs-workload-deploy.yaml
@@ -13,6 +13,7 @@ jobs: # using jobs so they each run in parallel
 
     - task: AzureCLI@2
       displayName: 'Install workload healthservice on AKS clusters'
+      retryCountOnTaskFailure: 2
       inputs:
         azureSubscription: $(azureServiceConnection)
         scriptType: pscore
@@ -74,6 +75,7 @@ jobs: # using jobs so they each run in parallel
 
     - task: AzureCLI@2
       displayName: 'Install workload CatalogService on AKS clusters'
+      retryCountOnTaskFailure: 2
       inputs:
         azureSubscription: $(azureServiceConnection)
         scriptType: pscore
@@ -160,6 +162,7 @@ jobs: # using jobs so they each run in parallel
 
     - task: AzureCLI@2
       displayName: 'Install workload BackgroundProcessor on AKS clusters'
+      retryCountOnTaskFailure: 2
       inputs:
         azureSubscription: $(azureServiceConnection)
         scriptType: pscore
@@ -222,6 +225,7 @@ jobs: # using jobs so they each run in parallel
 
     - task: AzureCLI@2
       displayName: 'Upload UI app to Blob Storage'
+      retryCountOnTaskFailure: 2
       inputs:
         azureSubscription: $(azureServiceConnection)
         scriptType: pscore

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -51,6 +51,7 @@ stages:
 
           - task: AzureCLI@2
             displayName: 'Fetch current Front Door backends'
+            retryCountOnTaskFailure: 1
             inputs:
               azureSubscription: '$(azureServiceConnection)'
               scriptType: pscore
@@ -310,6 +311,7 @@ stages:
             - ${{ if ne(parameters.environment, 'e2e') }}: # Only in int/prod
               - task: AzureCLI@2
                 displayName: 'Fetch previous release prefix through disabled Front Door backends'
+                retryCountOnTaskFailure: 1
                 inputs:
                   azureSubscription: '$(azureServiceConnection)'
                   scriptType: pscore
@@ -381,6 +383,7 @@ stages:
             # This prevents side effects in the logging in which errors might show up which are only related to the destructions of the infra
             - task: AzureCLI@2
               displayName: 'Delete application deployments on AKS prior to destroy'
+              retryCountOnTaskFailure: 1
               inputs:
                 azureSubscription: $(azureServiceConnection)
                 scriptType: pscore

--- a/.ado/pipelines/templates/steps-frontdoor-traffic-switch.yaml
+++ b/.ado/pipelines/templates/steps-frontdoor-traffic-switch.yaml
@@ -21,6 +21,7 @@ steps:
 
 - task: AzureCLI@2
   displayName: 'Create updated Front Door backend list'
+  retryCountOnTaskFailure: 1
   inputs:
     azureSubscription: $(azureServiceConnection)
     scriptType: pscore
@@ -164,6 +165,7 @@ steps:
 # After new backends have been added to Front Door, we purge the cache so that content will be retrieved from the new backends as well
 - task: AzureCLI@2
   displayName: 'Purge Front Door cache'
+  retryCountOnTaskFailure: 1
   inputs:
     azureSubscription: $(azureServiceConnection)
     scriptType: pscore

--- a/.ado/pipelines/templates/steps-set-pipeline-variables.yaml
+++ b/.ado/pipelines/templates/steps-set-pipeline-variables.yaml
@@ -3,6 +3,7 @@ steps:
 - task: PowerShell@2
   name: 'setPipelineVariables'
   displayName: 'Set pipeline variables'
+  retryCountOnTaskFailure: 1
   env:
     AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
   inputs:

--- a/.ado/pipelines/templates/steps-terraform-apply.yaml
+++ b/.ado/pipelines/templates/steps-terraform-apply.yaml
@@ -39,6 +39,7 @@ steps:
 - task: Bash@3
   displayName: 'Terraform apply'
   name: 'terraformapply'
+  retryCountOnTaskFailure: 1
   inputs:
     workingDirectory: ${{ parameters.terraformWorkingDirectory }}
     targetType: 'inline'

--- a/.ado/pipelines/templates/steps-terraform-destroy.yaml
+++ b/.ado/pipelines/templates/steps-terraform-destroy.yaml
@@ -33,6 +33,7 @@ steps:
 # Delete Terraform state file. We need to run this in any case, even if variables.oldReleaseCustomSuffix=='' since Terrraform init also will always run and thereby create an empty state file
 - task: AzureCLI@2
   displayName: 'Delete Terraform state file'
+  retryCountOnTaskFailure: 1
   inputs:
     azureSubscription: $(azureServiceConnection)
     scriptType: pscore

--- a/.ado/pipelines/templates/steps-terraform-init.yaml
+++ b/.ado/pipelines/templates/steps-terraform-init.yaml
@@ -8,6 +8,7 @@ steps:
 # Install Terraform tooling
 - task: Bash@3
   displayName: 'Install Terraform CLI v$(terraformVersion)'
+  retryCountOnTaskFailure: 1
   inputs:
     targetType: 'inline'
     script: |
@@ -21,6 +22,7 @@ steps:
 # https://github.com/Microsoft/azure-pipelines-tasks/issues/9554#issuecomment-526391527
 - task: AzureCLI@2
   displayName: 'Set Terraform Backend config env vars'
+  retryCountOnTaskFailure: 1
   inputs:
     azureSubscription: $(azureServiceConnection)
     addSpnToEnvironment: true
@@ -41,6 +43,7 @@ steps:
 
 - task: Bash@3
   displayName: 'Terraform init'
+  retryCountOnTaskFailure: 1
   inputs:
     workingDirectory: ${{ parameters.terraformWorkingDirectory }}
     targetType: 'inline'

--- a/.ado/pipelines/templates/steps-terraform-setup-statestore.yaml
+++ b/.ado/pipelines/templates/steps-terraform-setup-statestore.yaml
@@ -12,6 +12,7 @@ steps:
 # Check if Terraform state store exists and create it if not
 - task: AzureCLI@2
   displayName: 'Setup Terraform state store'
+  retryCountOnTaskFailure: 1
   inputs:
     azureSubscription: $(azureServiceConnection)
     scriptType: pscore

--- a/src/app/charts/catalogservice/templates/ingress.yaml
+++ b/src/app/charts/catalogservice/templates/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
   annotations:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "120"   #  Set timout to read from the backend pods to 120s. Cosmos DB retries can go up to 60s
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "120"   #  Set timeout to read from the backend pods to 120s. Cosmos DB retries can go up to 60s
     nginx.ingress.kubernetes.io/use-regex: "true"
     # Rewrite for the Location response header. Replaces the internal FQDN of the cluster with the base URL of the environment
     # Docs: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#proxy-redirect

--- a/src/app/charts/catalogservice/templates/ingress.yaml
+++ b/src/app/charts/catalogservice/templates/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
   annotations:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "120"   #  Set timout to read from the backend pods to 120s. Cosmos DB retries can go up to 60s
     nginx.ingress.kubernetes.io/use-regex: "true"
     # Rewrite for the Location response header. Replaces the internal FQDN of the cluster with the base URL of the environment
     # Docs: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#proxy-redirect


### PR DESCRIPTION
Learning from today's incident:
- Ingress ingress timout to higher than default of 60seconds in order to see actual errors from the backend instead of 504 Gateway timeouts
- Retry most of our ADO tasks at least once. Doesnt hurt and might "solve" many transient issues