### PR TITLE
Move nginx ingress to separate k8s namespace

### DIFF
--- a/.ado/pipelines/templates/jobs-configuration.yaml
+++ b/.ado/pipelines/templates/jobs-configuration.yaml
@@ -44,9 +44,15 @@ jobs:
           helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
           helm repo update
 
+          $ingressNamespace = "ingress-nginx"
+
+          echo "*** Create namespace '$ingressNamespace' on AKS cluster $aksClusterName via kubectl"
+          kubectl create namespace $ingressNamespace  `
+                    --dry-run=client --output yaml | kubectl apply -f -
+
           # Deploy helm chart for ingress-nginx using a custom load balancer ip and resource group
           helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx `
-                --namespace kube-system `
+                --namespace $ingressNamespace `
                 --values src/config/ingress-nginx/values.helm.yaml `
                 --set controller.service.loadBalancerIP="$aksIngressIp" `
                 --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-resource-group"="$aksClusterResourceGroup" `

--- a/src/app/charts/catalogservice/templates/ingress.yaml
+++ b/src/app/charts/catalogservice/templates/ingress.yaml
@@ -60,4 +60,3 @@ spec:
             name: {{ .Values.healthservice.name | quote }}
             port:
               number: {{ .Values.healthservice.port | default 80 }}
-  ingressClassName: nginx

--- a/src/app/charts/catalogservice/templates/ingress.yaml
+++ b/src/app/charts/catalogservice/templates/ingress.yaml
@@ -59,3 +59,4 @@ spec:
             name: {{ .Values.healthservice.name | quote }}
             port:
               number: {{ .Values.healthservice.port | default 80 }}
+  ingressClassName: nginx

--- a/src/app/charts/catalogservice/templates/networkpolicy.yaml
+++ b/src/app/charts/catalogservice/templates/networkpolicy.yaml
@@ -50,7 +50,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          kubernetes.io/metadata.name: kube-system
+          kubernetes.io/metadata.name: ingress-nginx
     ports:
     - port: {{ .Values.workload.port | default 8080 }}
 ---

--- a/src/app/charts/catalogservice/values.yaml
+++ b/src/app/charts/catalogservice/values.yaml
@@ -16,7 +16,6 @@ scale: # Horizontal Pod Autoscaler (HPA) configuration
 ingress:
   annotations:
     cert-manager.io/cluster-issuer: "cert-manager-alwayson"
-    kubernetes.io/ingress.class: nginx
 
 networkPolicy:
   enabled: true # Enable Network Policy (contains a default-deny policy)


### PR DESCRIPTION
To enable a better separation of concern, the ingress should not run in the `kube-system` namespace