### PR TITLE
Adding Kured for node reboots

### DIFF
--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -14,6 +14,8 @@ variables:
   value: '4.0.18'
 - name: 'certManagerVersion'  # cert-manager helm chart version
   value: 'v1.8.0'
+- name:  'kuredVersion'        # KUbernetes REboot Daemon helm chart version
+  value: '2.13.0'
 - name: 'dotnetSdkVersion'    # dotnet sdk version
   value: '6.0.200'
 - name: 'chaosMeshVersion'    #  chaos-mesh chart version

--- a/.ado/pipelines/templates/jobs-configuration.yaml
+++ b/.ado/pipelines/templates/jobs-configuration.yaml
@@ -204,14 +204,16 @@ jobs:
           az aks get-credentials --name $aksClusterName --resource-group $aksClusterResourceGroup --overwrite-existing
           echo "*** Installing the KUbernetes REboot Daemon (kured) via helm on $aksClusterName"
 
-          echo "*** Create namespace 'kured' on AKS cluster $aksClusterName via kubectl"
-          kubectl create namespace kured `
+          $kuredNamespace = "kube-system"
+
+          echo "*** Create namespace '$kuredNamespace' on AKS cluster $aksClusterName via kubectl"
+          kubectl create namespace $kuredNamespace `
                     --dry-run=client --output yaml | kubectl apply -f -
 
           helm repo add kured https://weaveworks.github.io/kured
           helm repo update
           helm upgrade --install kured kured/kured `
-                        --namespace kured `
+                        --namespace $kuredNamespace `
                         --values src/config/kured/kured.yaml `
                         --version $(kuredVersion)
         }

--- a/.ado/pipelines/templates/jobs-configuration.yaml
+++ b/.ado/pipelines/templates/jobs-configuration.yaml
@@ -183,6 +183,38 @@ jobs:
                         --set kvSecrets="{$allSecretNames}"
         }
 
+  - task: AzureCLI@2
+    displayName: 'Install kured on AKS clusters'
+    inputs:
+      azureSubscription: $(azureServiceConnection)
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        # load json data from downloaded pipeline artifact json
+        $releaseUnitInfraDeployOutput = Get-ChildItem $(Pipeline.Workspace)/terraformOutputReleaseUnitInfra/*.json | Get-Content | ConvertFrom-JSON
+
+        # loop through stamps from pipeline artifact json
+        foreach($stamp in $releaseUnitInfraDeployOutput.stamp_properties.value) {
+
+          $aksClusterName = $stamp.aks_cluster_name
+          $aksClusterResourceGroup = $stamp.resource_group_name
+
+          echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
+          # load AKS cluster credentials
+          az aks get-credentials --name $aksClusterName --resource-group $aksClusterResourceGroup --overwrite-existing
+          echo "*** Installing the KUbernetes REboot Daemon (kured) via helm on $aksClusterName"
+
+          echo "*** Create namespace 'kured' on AKS cluster $aksClusterName via kubectl"
+          kubectl create namespace kured `
+                    --dry-run=client --output yaml | kubectl apply -f -
+
+          helm repo add kured https://weaveworks.github.io/kured
+          helm repo update
+          helm upgrade --install kured kured/kured `
+                        --namespace kured `
+                        --values src/config/kured/kured.yaml `
+                        --version $(kuredVersion)
+
   - ${{ if eq(parameters.runChaosTesting, 'true') }}:
     - task: AzureCLI@2
       displayName: "Install Chaos Mesh $(chaosMeshVersion) on AKS clusters"

--- a/.ado/pipelines/templates/jobs-configuration.yaml
+++ b/.ado/pipelines/templates/jobs-configuration.yaml
@@ -214,6 +214,7 @@ jobs:
                         --namespace kured `
                         --values src/config/kured/kured.yaml `
                         --version $(kuredVersion)
+        }
 
   - ${{ if eq(parameters.runChaosTesting, 'true') }}:
     - task: AzureCLI@2

--- a/.ado/pipelines/templates/jobs-configuration.yaml
+++ b/.ado/pipelines/templates/jobs-configuration.yaml
@@ -206,9 +206,9 @@ jobs:
 
           $kuredNamespace = "kube-system"
 
-          echo "*** Create namespace '$kuredNamespace' on AKS cluster $aksClusterName via kubectl"
-          kubectl create namespace $kuredNamespace `
-                    --dry-run=client --output yaml | kubectl apply -f -
+          # echo "*** Create namespace '$kuredNamespace' on AKS cluster $aksClusterName via kubectl"
+          # kubectl create namespace $kuredNamespace `
+          #           --dry-run=client --output yaml | kubectl apply -f -
 
           helm repo add kured https://weaveworks.github.io/kured
           helm repo update

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -22,10 +22,11 @@ These version definitions are not only used for the components installed, but al
 
 The configuration layer is responsible for installing a set of components on top of the Azure resources, in this reference implementation mainly Azure Kubernetes Service, deployed as part of the infrastructure layer:
 
-* [ingress-nginx](#ingress-nginx)
-* [cert-manager](#cert-manager)
-* [csi-driver-keyvault](#csi-driver-keyvault)
-* [monitoring](#monitoring)
+- [ingress-nginx](#ingress-nginx)
+- [cert-manager](#cert-manager)
+- [csi-driver-keyvault](#csi-driver-keyvault)
+- [monitoring](#monitoring)
+- [kured](#kured)
 
 Additional configuration and manifests files used to configure the additional services are stored within the `/src/config` directory.
 
@@ -85,6 +86,14 @@ Monitoring contains an additional YAML manifest to update and change the OMSAgen
 ```
 
 Our ConfigMap disabled Prometheus-scraping and stdout/stderr collection to reduce the amount of monitoring data sent to the corresponding Log Analytics workspace (per regional deployment).
+
+### kured
+
+[Kured](https://docs.microsoft.com/azure/aks/node-updates-kured), the "KUbernetes REboot Daemon", is included as a solution to handle occasional required reboots from daily OS patching. While most system patches do not require a reboot, some do to come into effect.
+
+> Kured is rebooting Kubernetes worker nodes and will re-schedule pods to other nodes if needed, this might affect the availability of the overall solution. To cope with that, enough capacity should be available and the reboots should be configured to occur during less frequented times.
+
+> Kured is a [3rd-party component](https://github.com/weaveworks/kured) and not supported by Microsoft Support.
 
 ---
 

--- a/src/config/kured/kured.yaml
+++ b/src/config/kured/kured.yaml
@@ -7,4 +7,4 @@ service:
 
 configuration:
   period:     "12h0m0s" # reboot check period (default 1h0m0s)
-  rebootDays: [su,mo,tu,we,th,fr,sa]    # only reboot on these days (default [su,mo,tu,we,th,fr,sa])
+  rebootDays: [su,tu,th]    # only reboot on these days (default [su,mo,tu,we,th,fr,sa])

--- a/src/config/kured/kured.yaml
+++ b/src/config/kured/kured.yaml
@@ -7,4 +7,4 @@ service:
 
 configuration:
   period:     "12h0m0s" # reboot check period (default 1h0m0s)
-  rebootDays: [su]    # only reboot on these days (default [su,mo,tu,we,th,fr,sa])
+  rebootDays: [su,mo,tu,we,th,fr,sa]    # only reboot on these days (default [su,mo,tu,we,th,fr,sa])

--- a/src/config/kured/kured.yaml
+++ b/src/config/kured/kured.yaml
@@ -1,0 +1,10 @@
+service:
+  create: true
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path:   "/metrics"
+    prometheus.io/port:   "8080"
+
+configuration:
+  period:     "12h0m0s" # reboot check period (default 1h0m0s)
+  rebootDays: [su]    # only reboot on these days (default [su,mo,tu,we,th,fr,sa])

--- a/src/config/kured/kured.yaml
+++ b/src/config/kured/kured.yaml
@@ -8,3 +8,6 @@ service:
 configuration:
   period:     "1h0m0s"      # reboot check period
   rebootDays: [su,tu,th]    # only reboot on these days (default [su,mo,tu,we,th,fr,sa])
+  startTime: "1am"
+  endTime:   "4am"
+  timeZone:  "UTC"

--- a/src/config/kured/kured.yaml
+++ b/src/config/kured/kured.yaml
@@ -6,5 +6,5 @@ service:
     prometheus.io/port:   "8080"
 
 configuration:
-  period:     "12h0m0s" # reboot check period (default 1h0m0s)
+  period:     "1h0m0s"      # reboot check period
   rebootDays: [su,tu,th]    # only reboot on these days (default [su,mo,tu,we,th,fr,sa])


### PR DESCRIPTION
This PR installs Kured on the AKS clusters to handle node reboots which might be required do to nightly auto-updates, e.g. when Kernel updates need to be applied.

Still testing, I have an open deployment which should required (and do) the reboot in the next days/nights

Docs: https://docs.microsoft.com/en-us/azure/aks/node-updates-kured

@heoelri 