### PR TITLE
Configure ingress-nginx `externalTrafficPolicy` to fix issues

### DIFF
--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -11,7 +11,7 @@ variables:
 - name: 'helmVersion'         # helm package manager version
   value: 'v3.8.1'
 - name: 'ingressNginxVersion' # nginx ingress controller helm chart version
-  value: '4.0.18'
+  value: '4.1.0'
 - name: 'certManagerVersion'  # cert-manager helm chart version
   value: 'v1.8.0'
 - name: 'dotnetSdkVersion'    # dotnet sdk version

--- a/src/config/ingress-nginx/values.helm.yaml
+++ b/src/config/ingress-nginx/values.helm.yaml
@@ -23,7 +23,8 @@ controller:
         prometheus.io/scrape: "true"
         prometheus.io/port: "10254"
   service:
-    type:        LoadBalancer
+    externalTrafficPolicy: "Local" # denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints.
+    type: LoadBalancer
     enableHttp:  true # enable plain http (req. for cert-manager)
     enableHttps: true  # enable https listener
   config:


### PR DESCRIPTION
This PR bumps the `ingress-nginx` chart from `4.0.18` to `4.1.0` and configures the `externalTrafficPoliy` to `Local`.

> Preserving the client source IP
>By default, the source IP seen in the target container is not the original source IP of the client. To enable preservation of the client IP, the following fields can be configured in the .spec of the Service:
> 
> `.spec.externalTrafficPolicy` - denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. There are two available options: Cluster (default) and Local. Cluster obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading. Local preserves the client source IP and avoids a second hop for LoadBalancer and NodePort type Services, but risks potentially imbalanced traffic spreading.
> https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/