### PR TITLE
Change `ingress-nginx` health probe path

### DIFF
--- a/src/config/ingress-nginx/values.helm.yaml
+++ b/src/config/ingress-nginx/values.helm.yaml
@@ -23,10 +23,11 @@ controller:
         prometheus.io/scrape: "true"
         prometheus.io/port: "10254"
   service:
-    externalTrafficPolicy: "Local" # denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints.
     type: LoadBalancer
     enableHttp:  true # enable plain http (req. for cert-manager)
     enableHttps: true  # enable https listener
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/healthz"
   config:
     # Use a custom, more structured logging format
     log-format-upstream: '{"time": "$time_iso8601", "remote_addr": "$remote_addr", "request_id": "$req_id", "http_traceparent": "$http_traceparent", "http_correlation_id": "$sent_http_x_correlation_id", "bytes_sent": $bytes_sent, "request_time": $request_time, "status": $status, "vhost": "$host", "request_proto": "$server_protocol", "path": "$uri", "request_query": "$args", "request_length": $request_length, "duration": $request_time,"method": "$request_method", "http_referrer": "$http_referer","http_user_agent": "$http_user_agent", "upstream_addr": "$upstream_addr", "response_length": "$upstream_response_length", "response_time": "$upstream_response_time", "response_status": "$upstream_status" }'


### PR DESCRIPTION
This replaces the previously used workaround using `controller.service.externalTrafficPolicy` with `service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/healthz"`. As discussed in https://github.com/MicrosoftDocs/azure-docs-pr/pull/195986 and https://github.com/Azure/AKS/issues/2903.

Successfully tested in https://dev.azure.com/mission-critical/Online/_build/results?buildId=1142&view=logs&j=dcf15632-8d99-5a2f-34ca-ab8a9c986548&t=dcf15632-8d99-5a2f-34ca-ab8a9c986548