### PR TITLE
Pull `grafana` and `nginx` from `mcr.microsoft.com`

### DIFF
--- a/src/app/AlwaysOn.UI/Dockerfile
+++ b/src/app/AlwaysOn.UI/Dockerfile
@@ -10,7 +10,7 @@ RUN npm install && \
     npm run build
 
 # Create application container
-FROM nginx:alpine
+FROM mcr.microsoft.com/oss/nginx/nginx:1.17.5-alpine
 # Copy build artifacts from previous stage build-env
 COPY --from=build-env /app/dist /usr/share/nginx/html
 EXPOSE 80

--- a/src/infra/monitoring/grafana/Dockerfile
+++ b/src/infra/monitoring/grafana/Dockerfile
@@ -18,7 +18,7 @@ RUN npm install
 
 # We're using Grafana 8.3.4 now since later versions give us issues with the header settings behind Front Door. 
 # As soon as that is resolved, we'll get back on the latest version. 
-FROM grafana/grafana:8.3.4
+FROM mcr.microsoft.com/oss/grafana/grafana:8.3.4
 
 # In order to run unsigned plugins such as our health model panel, we need to explicitly allow them in an env variable. 
 ENV GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS="healthmodelpanel"


### PR DESCRIPTION
This PR updates the Dockerfiles for grafana and the AlwaysOn.UI to pull `grafana` and `nginx` from `mcr.microsoft.com` instead of `hub.docker.com`. In preparation for the announced throttling of Docker Hub:

> Docker Hub limits the number of Docker image downloads (“pulls”) based on the account type of the user pulling the image. Pull rates limits are based on individual IP address. For anonymous users, the rate limit is set to 100 pulls per 6 hours per IP address. For [authenticated](https://docs.docker.com/docker-hub/download-rate-limit/#how-do-i-authenticate-pull-requests) users, it is 200 pulls per 6 hour period.
> https://docs.docker.com/docker-hub/download-rate-limit