### PR TITLE
Individual Ingress rules per service/helm chart

### DIFF
--- a/.ado/pipelines/templates/jobs-workload-deploy.yaml
+++ b/.ado/pipelines/templates/jobs-workload-deploy.yaml
@@ -44,8 +44,11 @@ jobs: # using jobs so they each run in parallel
             echo  "*** Deploy healthservice to $aksClusterName (in $aksClusterResourceGroup) via helm chart"
             helm upgrade --install healthservice-workload src/app/charts/healthservice `
                           --namespace $(workloadNamespace) --create-namespace `
-                          --set containerimage="$fullContainerImageName" `
+                          --set azure.frontdoorid="$frontDoorId" `
                           --set azure.region="$region" `
+                          --set azure.baseurl="$frontDoorFqdn" `
+                          --set containerimage="$fullContainerImageName" `
+                          --set workload.domainname="$fqdn" `
                           ${{ parameters.additionalHelmArguments }}
 
             # Wait for healthservice-deploy k8s deployment to come up

--- a/.ado/pipelines/templates/jobs-workload-deploy.yaml
+++ b/.ado/pipelines/templates/jobs-workload-deploy.yaml
@@ -25,6 +25,14 @@ jobs: # using jobs so they each run in parallel
           # load json data from downloaded terraform artifact
           $releaseUnitInfraDeployOutput = Get-ChildItem $(Pipeline.Workspace)/terraformOutputReleaseUnitInfra/*.json | Get-Content | ConvertFrom-JSON
 
+          $globalInfraDeployOutput = Get-ChildItem $(Pipeline.Workspace)/terraformOutputGlobalInfra/*.json | Get-Content | ConvertFrom-JSON
+
+          $frontDoorId = $globalInfraDeployOutput.frontdoor_id_header.value
+          echo "*** Retrieved Azure Front Door Header ID $frontDoorId"
+
+          $frontDoorFqdn = $globalInfraDeployOutput.frontdoor_fqdn.value
+          echo "*** Retrieved Azure Front Door FQDN $frontDoorFqdn"
+
           # loop through stamps from pipeline artifact json
           foreach($stamp in $releaseUnitInfraDeployOutput.stamp_properties.value) {
 
@@ -39,6 +47,9 @@ jobs: # using jobs so they each run in parallel
 
             $fullContainerImageName = Get-Content -Path "$(Pipeline.Workspace)/healthservice-containerImageName/healthservice.txt"
             echo "*** Retrieved container image name from artifact - $fullContainerImageName"
+
+            $fqdn = $stamp.aks_cluster_ingress_fqdn
+            echo "*** Retrieved Ingress Controller FQDN $fqdn for AKS cluster $aksClusterName"
 
             # Apply workload worker helm chart
             echo  "*** Deploy healthservice to $aksClusterName (in $aksClusterResourceGroup) via helm chart"

--- a/src/app/charts/catalogservice/templates/ingress.yaml
+++ b/src/app/charts/catalogservice/templates/ingress.yaml
@@ -34,7 +34,7 @@ spec:
   tls:
   - hosts:
     - {{ .Values.workload.domainname }}
-    secretName: {{ .Chart.Name }}-ingress-secret
+    secretName: workload-ingress-secret # shouldn't be changed as this might be used by other services
   rules:
   - host: {{ .Values.workload.domainname }}
     http:
@@ -53,10 +53,3 @@ spec:
             name: {{ .Chart.Name }}-service
             port:
               number: {{ .Values.workload.service.port | default 80 }}
-      - path: /health # exposing the 'healthservice'
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ .Values.healthservice.name | quote }}
-            port:
-              number: {{ .Values.healthservice.port | default 80 }}

--- a/src/app/charts/catalogservice/templates/ingress.yaml
+++ b/src/app/charts/catalogservice/templates/ingress.yaml
@@ -34,7 +34,7 @@ spec:
   tls:
   - hosts:
     - {{ .Values.workload.domainname }}
-    secretName: workload-ingress-secret # shouldn't be changed as this might be used by other services
+    secretName: {{ .Values.workload.tlsSecret }} # shouldn't be changed as this might be used by other services
   rules:
   - host: {{ .Values.workload.domainname }}
     http:

--- a/src/app/charts/catalogservice/values.yaml
+++ b/src/app/charts/catalogservice/values.yaml
@@ -15,7 +15,7 @@ scale: # Horizontal Pod Autoscaler (HPA) configuration
 
 ingress:
   annotations:
-    cert-manager.io/cluster-issuer: "cert-manager-alwayson"
+    cert-manager.io/cluster-issuer: "cert-manager-alwayson" # this will trigger cert-manager to request a certificate
 
 networkPolicy:
   enabled: true # Enable Network Policy (contains a default-deny policy)
@@ -25,7 +25,3 @@ azure:
   frontdoorid: "" # Azure Front Door Header ID (blank = disabled)
   region: "East US 2"
   baseurl: "OVERWRITE.myalwaysonapp.net" # FQDN used by the Azure Front Door endpoint
-
-healthservice:
-  name: "healthservice-service" # name of the healthservice service in k8s
-  port: 80

--- a/src/app/charts/catalogservice/values.yaml
+++ b/src/app/charts/catalogservice/values.yaml
@@ -4,6 +4,7 @@ container:
 
 workload:
   domainname: "OVERWRITE-cluster.eastus2.cloudapp.azure.com" # External Domain Name of the AKS cluster (used for Ingress)
+  tlsSecret: workload-ingress-secret # k8s secret name for the tls cert - make sure that the name is the same when shared
   port: 8080 # Port of the container workload
   service:
     port: 80 # Service Port (not used for Ingress)

--- a/src/app/charts/healthservice/templates/ingress.yaml
+++ b/src/app/charts/healthservice/templates/ingress.yaml
@@ -1,3 +1,48 @@
-# How's the health service exposed?
-# The healthservice is only available within the cluster 
-# and is getting exposed via the CatalogService on /health
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Chart.Name }}-ingress
+  labels:
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+  annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "120"   #  Set timeout to read from the backend pods to 120s. Cosmos DB retries can go up to 60s
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    # Rewrite for the Location response header. Replaces the internal FQDN of the cluster with the base URL of the environment
+    # Docs: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#proxy-redirect
+    # Backend header might look like this: http://adaptedanteater-cluster.northeurope.cloudapp.azure.com/api/1.0/game/123
+    # Will be rewritte to something like https://aoint-app.alwaysonapp.net/api/1.0/game/123
+    nginx.ingress.kubernetes.io/proxy-redirect-from: "~^((http|https)://.+?)/(.+)$"
+    nginx.ingress.kubernetes.io/proxy-redirect-to: "https://{{ .Values.azure.baseurl }}/$3"
+  {{- if .Values.azure.frontdoorid }}
+    # To restric traffic coming only through our Front Door instance, we use a header check on the X-Azure-FDID
+    # The value gets injected by the pipeline. Hence, this ID should be treated as a senstive value
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecRule &REQUEST_HEADERS:X-Azure-FDID \"@eq 0\"  \"log,deny,id:106,status:403,msg:\'Front Door ID not present\'\"
+      SecRule REQUEST_HEADERS:X-Azure-FDID \"@rx ^(?!{{ .Values.azure.frontdoorid }}).*$\"  \"log,deny,id:107,status:403,msg:\'Wrong Front Door ID\'\"
+  {{- end }}
+  {{- if .Values.ingress.annotations }}
+  {{ toYaml .Values.ingress.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - {{ .Values.workload.domainname }}
+    secretName: workload-ingress-secret # shouldn't be changed as this might be used by other services
+  rules:
+  - host: {{ .Values.workload.domainname }}
+    http:
+      paths:
+      - path: /health # exposing the 'healthservice'
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Chart.Name }}-service
+            port:
+              number: {{ .Values.workload.port | default 80 }}

--- a/src/app/charts/healthservice/templates/ingress.yaml
+++ b/src/app/charts/healthservice/templates/ingress.yaml
@@ -34,7 +34,7 @@ spec:
   tls:
   - hosts:
     - {{ .Values.workload.domainname }}
-    secretName: workload-ingress-secret # shouldn't be changed as this might be used by other services
+    secretName: {{ .Values.workload.tlsSecret }} # shouldn't be changed as this might be used by other services
   rules:
   - host: {{ .Values.workload.domainname }}
     http:

--- a/src/app/charts/healthservice/values.yaml
+++ b/src/app/charts/healthservice/values.yaml
@@ -3,6 +3,7 @@ container:
   pullPolicy: "IfNotPresent" # Container Image Pull Policy. Using IfNotPresent to enable pod starts even if ACR cannot be reached and image was pulled on the node previously
 
 workload:
+  domainname: "OVERWRITE-cluster.eastus2.cloudapp.azure.com" # External Domain Name of the AKS cluster (used for Ingress)
   port: 8080 # Port of the container workload
   service:
     port: 80 # Service Port (not used for Ingress)
@@ -17,4 +18,6 @@ networkPolicy:
   enabled: true # Enable Network Policy
 
 azure:
+  frontdoorid: "" # Azure Front Door Header ID (blank = disabled)
   region: "East US 2"
+  baseurl: "OVERWRITE.myalwaysonapp.net" # FQDN used by the Azure Front Door endpoint

--- a/src/app/charts/healthservice/values.yaml
+++ b/src/app/charts/healthservice/values.yaml
@@ -21,3 +21,6 @@ azure:
   frontdoorid: "" # Azure Front Door Header ID (blank = disabled)
   region: "East US 2"
   baseurl: "OVERWRITE.myalwaysonapp.net" # FQDN used by the Azure Front Door endpoint
+
+ingress:
+  annotations:

--- a/src/app/charts/healthservice/values.yaml
+++ b/src/app/charts/healthservice/values.yaml
@@ -4,6 +4,7 @@ container:
 
 workload:
   domainname: "OVERWRITE-cluster.eastus2.cloudapp.azure.com" # External Domain Name of the AKS cluster (used for Ingress)
+  tlsSecret: workload-ingress-secret # k8s secret name for the tls cert - make sure that the name is the same when shared
   port: 8080 # Port of the container workload
   service:
     port: 80 # Service Port (not used for Ingress)


### PR DESCRIPTION
This PR splits the single ingress rule that exposes the `catalogservice` and the `healthservice` that currently exist only in the `catalogservice` helm chart into individual ingress rules per service, packaged together with the service in individual helm charts. See discussion in PR #351 for more details.