### PR TITLE
API paths per service

### DIFF
--- a/.ado/pipelines/README.md
+++ b/.ado/pipelines/README.md
@@ -91,10 +91,10 @@ All pipelines are using Azure DevOps service connections to connect to Microsoft
 
 As part of the pipelines, basic Smoke Tests against the APIs are executed:
 
-- GET call to the HealthService `/health/stamp` API. Expected result: HTTP 200
-- GET call the CatalogService `/api/1.0/catalogitem` API to retrieve a list of existing items. Expected result: HTTP 200
-- POST call to the CatalogService `/api/1.0/catalogitem/{itemId}/comments` API to create a new comment for an existing item. Expected result: HTTP 202
-- GET call to the CatalogService `/api/1.0/catalogitem/{itemId}/comments/{commentId}` API to retrieve the previously created comment. Expected result: HTTP 200
+- GET call to the HealthService `/healthservice/health/stamp` API. Expected result: HTTP 200
+- GET call the CatalogService `/catalogservice/api/1.0/catalogitem` API to retrieve a list of existing items. Expected result: HTTP 200
+- POST call to the CatalogService `/catalogservice/api/1.0/catalogitem/{itemId}/comments` API to create a new comment for an existing item. Expected result: HTTP 202
+- GET call to the CatalogService `/catalogservice/api/1.0/catalogitem/{itemId}/comments/{commentId}` API to retrieve the previously created comment. Expected result: HTTP 200
 
 The calls are first executed against the individual stamps to test the availability of each regional deployment and afterwards against the global Front Door endpoint, which distributes the requests to the different stamps.
 

--- a/.ado/pipelines/templates/jobs-init-sampledata.yaml
+++ b/.ado/pipelines/templates/jobs-init-sampledata.yaml
@@ -30,7 +30,7 @@ jobs:
           # We cannot send it through Front Door at this point, since the new stamp might not be wired up yet in AFD
           $stamp = $releaseUnitInfraDeployOutput.stamp_properties.value[0]
 
-          $url = "https://$($stamp.aks_cluster_ingress_fqdn)/api/1.0/CatalogItem"
+          $url = "https://$($stamp.aks_cluster_ingress_fqdn)/catalogservice/api/1.0/CatalogItem"
 
           Write-Host "*** Using URL $url"
 

--- a/.ado/pipelines/templates/jobs-workload-deploy.yaml
+++ b/.ado/pipelines/templates/jobs-workload-deploy.yaml
@@ -251,7 +251,7 @@ jobs: # using jobs so they each run in parallel
 
             echo "*** Storing configuration to $configFilePath"
             # warning: make sure that these variable names are in sync with client code
-            Add-Content -Path $configFilePath -Value "window.API_URL = `"/api`""
+            Add-Content -Path $configFilePath -Value "window.API_URL = `"/catalogservice/api`""
             Add-Content -Path $configFilePath -Value "window.APPLICATIONINSIGHTS_CONNECTION_STRING = `"$appInsightsConnString`""
 
             $versionLabel = "$(riVariant)-$("$(Build.SourceBranch)" -Replace 'refs/heads/', '')-$(Build.BuildId)"

--- a/.ado/scripts/SmokeTest.ps1
+++ b/.ado/scripts/SmokeTest.ps1
@@ -94,14 +94,14 @@ foreach($target in $targets) {
 
   # test health endpoints for stamps only
   if ($mode -eq "stamp") {
-    $stampHealthUrl = "https://$targetFqdn/health/stamp"
+    $stampHealthUrl = "https://$targetFqdn/healthservice/health/stamp"
     Write-Output "*** Call - Stamp Health ($mode)"
 
     # custom retry loop to handle the situation when the SSL certificate is not valid yet and Invoke-WebRequest throws an exception
     Invoke-WebRequestWithRetry -Uri $stampHealthUrl -Method 'GET' -Headers $header -MaximumRetryCount $smokeTestRetryCount -RetryWaitSeconds $smokeTestRetryWaitSeconds
   }
 
-  $listCatalogUrl = "https://$targetFqdn/api/1.0/catalogitem"
+  $listCatalogUrl = "https://$targetFqdn/catalogservice/api/1.0/catalogitem"
   Write-Output "*** Call - List Catalog ($mode)"
   $responseListCatalog = Invoke-WebRequestWithRetry -Uri $listCatalogUrl -Method 'get' -Headers $header -MaximumRetryCount $smokeTestRetryCount -RetryWaitSeconds $smokeTestRetryWaitSeconds
   $responseListCatalog
@@ -114,11 +114,11 @@ foreach($target in $targets) {
 
   $randomItem = Get-Random $allItems
 
-  $itemUrl = "https://$targetFqdn/api/1.0/catalogitem/$($randomItem.id)"
+  $itemUrl = "https://$targetFqdn/catalogservice/api/1.0/catalogitem/$($randomItem.id)"
   Write-Output "*** Call - Get get item ($($randomItem.id)) ($mode)"
   Invoke-WebRequestWithRetry -Uri $itemUrl -Method 'GET' -Headers $header -MaximumRetryCount $smokeTestRetryCount -RetryWaitSeconds $smokeTestRetryWaitSeconds
 
-  $postCommentUrl = "https://$targetFqdn/api/1.0/catalogitem/$($randomItem.id)/comments"
+  $postCommentUrl = "https://$targetFqdn/catalogservice/api/1.0/catalogitem/$($randomItem.id)/comments"
   Write-Output "*** Call - Post new comment to item $($randomItem.id) ($mode)"
 
   $responsePostComment = Invoke-WebRequestWithRetry -Uri $postCommentUrl -Method 'POST' -Headers $header -Body $post_comment_body -MaximumRetryCount $smokeTestRetryCount -RetryWaitSeconds $smokeTestRetryWaitSeconds -ExpectedResponseCode 202

--- a/src/app/AlwaysOn.CatalogService/README.md
+++ b/src/app/AlwaysOn.CatalogService/README.md
@@ -107,7 +107,7 @@ public async Task<ActionResult<CatalogItem>> GetCatalogItemByIdAsyncV2(Guid item
 }
 ```
 
-- Providing version string in the URL is mandatory (e.g. `https://localhost:5000/1.0/catalogitem/` or `https://ao6bd5-global-fd.azurefd.net/api/1.0/catalogitem`).
+- Providing version string in the URL is mandatory (e.g. `https://localhost:5000/1.0/catalogitem/` or `https://ao6bd5-global-fd.azurefd.net/catalogservice/api/1.0/catalogitem`).
 - If version is `1.0`, the first implementation will get called (`GetCatalogItemByIdAsync`).
 - If version is `2.0`, the second implementation will get called (`GetCatalogItemByIdAsyncV2`).
 - If version `3.0` is specified on the controller, but no actions map to it, first implementation will be called.

--- a/src/app/AlwaysOn.CatalogService/Startup.cs
+++ b/src/app/AlwaysOn.CatalogService/Startup.cs
@@ -89,6 +89,8 @@ namespace AlwaysOn.CatalogService
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            app.UsePathBase("/catalogservice");
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
@@ -108,7 +110,7 @@ namespace AlwaysOn.CatalogService
                 // specifying the Swagger JSON endpoint.
                 app.UseSwaggerUI(c =>
                 {
-                    c.SwaggerEndpoint("/swagger/v1/swagger.json", "AlwaysOn CatalogService");
+                    c.SwaggerEndpoint("v1/swagger.json", "AlwaysOn CatalogService");
                 });
             }
 

--- a/src/app/AlwaysOn.HealthService/Startup.cs
+++ b/src/app/AlwaysOn.HealthService/Startup.cs
@@ -72,6 +72,8 @@ namespace AlwaysOn.HealthService
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            app.UsePathBase("/healthservice");
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
@@ -87,7 +89,7 @@ namespace AlwaysOn.HealthService
                 // specifying the Swagger JSON endpoint.
                 app.UseSwaggerUI(c =>
                 {
-                    c.SwaggerEndpoint("/swagger/v1/swagger.json", "AlwaysOn HealthService");
+                    c.SwaggerEndpoint("v1/swagger.json", "AlwaysOn HealthService");
                 });
             }
 

--- a/src/app/charts/catalogservice/templates/ingress.yaml
+++ b/src/app/charts/catalogservice/templates/ingress.yaml
@@ -11,6 +11,9 @@ metadata:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "120"   #  Set timeout to read from the backend pods to 120s. Cosmos DB retries can go up to 60s
     nginx.ingress.kubernetes.io/use-regex: "true"
+    # Optionally, we could rewrite taret path to remove the name of the service. However, this might break some things like Location header rewrites for the response
+    # nginx.ingress.kubernetes.io/rewrite-target: /$2
+
     # Rewrite for the Location response header. Replaces the internal FQDN of the cluster with the base URL of the environment
     # Docs: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#proxy-redirect
     # Backend header might look like this: http://adaptedanteater-cluster.northeurope.cloudapp.azure.com/api/1.0/game/123
@@ -39,21 +42,14 @@ spec:
   - host: {{ .Values.workload.domainname }}
     http:
       paths:
-      - path: /(api|swagger).*
+      - path: /catalogservice(/|$)(.*) # exposing the 'catalogservice'
         pathType: Prefix
         backend:
           service:
             name: {{ .Chart.Name }}-service
             port:
               number: {{ .Values.workload.service.port | default 80 }}
-      - path: /swagger # exposing the swagger endpoint
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ .Chart.Name }}-service
-            port:
-              number: {{ .Values.workload.service.port | default 80 }}
-      - path: /health # exposing the 'healthservice'
+      - path: /healthservice(/|$)(.*) # exposing the 'healthservice'
         pathType: Prefix
         backend:
           service:

--- a/src/infra/workload/globalresources/frontdoor.tf
+++ b/src/infra/workload/globalresources/frontdoor.tf
@@ -11,7 +11,7 @@ resource "azurerm_frontdoor" "main" {
   routing_rule {
     name               = "API-rule"
     accepted_protocols = ["Https"]
-    patterns_to_match  = ["/api/*", "/health/*", "/swagger/*"]
+    patterns_to_match  = ["/catalogservice/*", "/healthservice/*"]
     frontend_endpoints = [(var.custom_fqdn != "" ? local.frontdoor_custom_frontend_name : local.frontdoor_default_frontend_name)]
     forwarding_configuration {
       forwarding_protocol = "HttpsOnly"
@@ -66,7 +66,7 @@ resource "azurerm_frontdoor" "main" {
     name                = "ApiHealthProbeSetting"
     protocol            = "Https"
     probe_method        = "HEAD"
-    path                = "/health/stamp"
+    path                = "/healthservice/health/stamp"
     interval_in_seconds = 30
   }
 

--- a/src/infra/workload/globalresources/monitoring_webtests.tf
+++ b/src/infra/workload/globalresources/monitoring_webtests.tf
@@ -19,7 +19,7 @@ resource "azurerm_application_insights_web_test" "api_ping" {
   configuration = <<XML
 <WebTest Name="${local.prefix}-appinsights-webtest-api-global" Id="00000000-0000-0000-0000-000000000000" Enabled="True" CssProjectStructure="" CssIteration="" Timeout="30" WorkItemIds="" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010" Description="" CredentialUserName="" CredentialPassword="" PreAuthenticate="True" Proxy="default" StopOnError="False" RecordedResultFile="" ResultsLocale="">
   <Items>
-    <Request Method="GET" Guid="00000000-0000-0000-0000-000000000000" Version="1.1" Url="https://${var.custom_fqdn != "" ? var.custom_fqdn : azurerm_frontdoor.main.cname}/api/1.0/catalogitem/?limit=1" ThinkTime="0" Timeout="30" ParseDependentRequests="False" FollowRedirects="False" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False" />
+    <Request Method="GET" Guid="00000000-0000-0000-0000-000000000000" Version="1.1" Url="https://${var.custom_fqdn != "" ? var.custom_fqdn : azurerm_frontdoor.main.cname}/catalogservice/api/1.0/catalogitem/?limit=1" ThinkTime="0" Timeout="30" ParseDependentRequests="False" FollowRedirects="False" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False" />
   </Items>
 </WebTest>
 XML

--- a/src/infra/workload/releaseunit/modules/stamp/monitoring_webtests.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/monitoring_webtests.tf
@@ -18,7 +18,7 @@ resource "azurerm_application_insights_web_test" "cluster_ping" {
   configuration = <<XML
 <WebTest Name="${local.prefix}-appinsights-webtest-cluster-${local.location_short}" Id="00000000-0000-0000-0000-000000000000" Enabled="True" CssProjectStructure="" CssIteration="" Timeout="30" WorkItemIds="" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010" Description="" CredentialUserName="" CredentialPassword="" PreAuthenticate="True" Proxy="default" StopOnError="False" RecordedResultFile="" ResultsLocale="">
   <Items>
-    <Request Method="GET" Guid="00000000-0000-0000-0000-000000000000" Version="1.1" Url="https://${azurerm_public_ip.aks_ingress.fqdn}/health/stamp" ThinkTime="0" Timeout="30" ParseDependentRequests="False" FollowRedirects="False" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False">
+    <Request Method="GET" Guid="00000000-0000-0000-0000-000000000000" Version="1.1" Url="https://${azurerm_public_ip.aks_ingress.fqdn}/healthservice/health/stamp" ThinkTime="0" Timeout="30" ParseDependentRequests="False" FollowRedirects="False" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False">
       <Headers>
         <Header Name="X-Azure-FDID" Value="${var.frontdoor_id_header}" />
       </Headers>

--- a/src/testing/loadtest-azure/scripts/catalog-test.jmx
+++ b/src/testing/loadtest-azure/scripts/catalog-test.jmx
@@ -91,7 +91,7 @@
             <stringProp name="HTTPSampler.port"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/api/1.0/catalogitem</stringProp>
+            <stringProp name="HTTPSampler.path">/catalogservice/api/1.0/catalogitem</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -117,7 +117,7 @@
             <stringProp name="HTTPSampler.port"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/api/1.0/catalogitem/${catalogItemId}</stringProp>
+            <stringProp name="HTTPSampler.path">/catalogservice/api/1.0/catalogitem/${catalogItemId}</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -146,7 +146,7 @@
             <stringProp name="HTTPSampler.port"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/api/1.0/catalogitem/${catalogItemId}/ratings</stringProp>
+            <stringProp name="HTTPSampler.path">/catalogservice/api/1.0/catalogitem/${catalogItemId}/ratings</stringProp>
             <stringProp name="HTTPSampler.method">POST</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -176,7 +176,7 @@
             <stringProp name="HTTPSampler.port"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/api/1.0/catalogitem/${catalogItemId}/comments</stringProp>
+            <stringProp name="HTTPSampler.path">/catalogservice/api/1.0/catalogitem/${catalogItemId}/comments</stringProp>
             <stringProp name="HTTPSampler.method">POST</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>

--- a/src/testing/loadtest-locust/locustfile.py
+++ b/src/testing/loadtest-locust/locustfile.py
@@ -18,7 +18,7 @@ class WebsiteUserSequence(SequentialTaskSet):
     @task(2)
     def list_catalogitems(self):
         # Get list of catatlog items
-        with self.client.get("/api/1.0/catalogitem", name="GET List of CatalogItems", catch_response=True) as response:
+        with self.client.get("/catalogservice/api/1.0/catalogitem", name="GET List of CatalogItems", catch_response=True) as response:
             if response.status_code != 200:
                 logging.error(f"(list_catalogitems) - failed response. Code: {response.status_code}")
                 response.failure(f"Got wrong response. Code: {response.status_code}")
@@ -30,7 +30,7 @@ class WebsiteUserSequence(SequentialTaskSet):
     @task(20)
     def show_catalogitem(self):
         # Open a catalog item
-        with self.client.get(f"/api/1.0/catalogitem/{self.randomItemId}", name="GET Catalog Item", catch_response=True) as response:
+        with self.client.get(f"/catalogservice/api/1.0/catalogitem/{self.randomItemId}", name="GET Catalog Item", catch_response=True) as response:
             if response.status_code != 200:
                 logging.error(f"(show_catalogitem) - failed response. Code: {response.status_code}")
                 response.failure(f"Got wrong response. Code: {response.status_code}")
@@ -41,7 +41,7 @@ class WebsiteUserSequence(SequentialTaskSet):
         json_body = {
             "rating": random.randint(1, 5)
         }
-        with self.client.post(f"/api/1.0/catalogitem/{self.randomItemId}/ratings", json=json_body, name="POST new rating", headers=self.headers, catch_response=True) as response:
+        with self.client.post(f"/catalogservice/api/1.0/catalogitem/{self.randomItemId}/ratings", json=json_body, name="POST new rating", headers=self.headers, catch_response=True) as response:
             if response.status_code != 202:
                 logging.error(f"(post_new_rating) - failed response. Code: {response.status_code}")
                 response.failure(f"Got wrong response. Code: {response.status_code}")
@@ -53,7 +53,7 @@ class WebsiteUserSequence(SequentialTaskSet):
             "authorName": "Locust Test User",
             "text": "This is a load test entry"
         }
-        with self.client.post(f"/api/1.0/catalogitem/{self.randomItemId}/comments", json=json_body, name="POST new comment", headers=self.headers, catch_response=True) as response:
+        with self.client.post(f"/catalogservice/api/1.0/catalogitem/{self.randomItemId}/comments", json=json_body, name="POST new comment", headers=self.headers, catch_response=True) as response:
             if response.status_code != 202:
                 logging.error(f"(post_new_comment) - failed response. Code: {response.status_code}")
                 response.failure(f"Got wrong response. Code: {response.status_code}")


### PR DESCRIPTION
This also requires that each service is aware of the specific path-prefix, otherwise this requires a lot of rewrite-magic at each reverse proxy stage which in some cases doesn't even properly work at all. Thus the changes on the application code side to add the base path there.

It also enables to expose each swagger UI (when enabled). Currently running here:

https://afe2edd5b-global-fd.azurefd.net/
https://afe2edd5b-global-fd.azurefd.net/catalogservice/swagger
https://afe2edd5b-global-fd.azurefd.net/healthservice/swagger