### PR TITLE
Various chaos and load test configuration updates

### DIFF
--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -51,17 +51,17 @@ variables:
 
 # Microsoft Azure Load Test (MALT) configuration
 - name: 'azureLoadTestEngineInstances'
-  value: 1
+  value: '1'
 - name: 'azureLoadTestVUsers'
-  value: 10
+  value: '10'
 - name: 'azureLoadTestDurationSeconds'
-  value: 660
+  value: '660'
 - name: 'azureLoadTestUserThreads'
-  value: 50
+  value: '50'
 
 # Chaos studio configuration
 - name: 'chaosExperimentDurationSeconds'
-  value: 180
+  value: '180'
 
 # Others
 - name: 'smokeTestRetryCount' # How many times a request in the smoke tests is retried before declared as failed (retries HTTP response codes from 400-599 as well as issues like certificate errors)

--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -41,27 +41,27 @@ variables:
 # Embedded load testing configuration
 # Make sure that these parameters are aligned with the loadtest-baseline.yaml
 - name: 'loadTestNumberOfWorkerNodes' # number of worker nodes
-  value: '10'
+  value: 10
 - name: 'loadTestDurationInSeconds' # load test duration
-  value: '600'
+  value: 600
 - name: 'loadTestNumberOfUsers' # number of simulated users in the load test
-  value: '500'
+  value: 500
 - name: 'loadTestUserSpawnRate' # load test spawn rate users / per second
-  value: '10'
+  value: 10
 
 # Microsoft Azure Load Test (MALT) configuration
 - name: 'azureLoadTestEngineInstances'
-  value: '1'
+  value: 1
 - name: 'azureLoadTestVUsers'
-  value: '10'
+  value: 10
 - name: 'azureLoadTestDurationSeconds'
-  value: '660'
+  value: 660
 - name: 'azureLoadTestUserThreads'
-  value: '50'
+  value: 50
 
 # Chaos studio configuration
 - name: 'chaosExperimentDurationSeconds'
-  value: '180'
+  value: 180
 
 # Others
 - name: 'smokeTestRetryCount' # How many times a request in the smoke tests is retried before declared as failed (retries HTTP response codes from 400-599 as well as issues like certificate errors)

--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -51,13 +51,17 @@ variables:
 
 # Microsoft Azure Load Test (MALT) configuration
 - name: 'azureLoadTestEngineInstances'
-  value: '1'
+  value: 1
 - name: 'azureLoadTestVUsers'
-  value: '10'
+  value: 10
 - name: 'azureLoadTestDurationSeconds'
-  value: '300'
+  value: 660
 - name: 'azureLoadTestUserThreads'
-  value: '100'
+  value: 50
+
+# Chaos studio configuration
+- name: 'chaosExperimentDurationSeconds'
+  value: 180
 
 # Others
 - name: 'smokeTestRetryCount' # How many times a request in the smoke tests is retried before declared as failed (retries HTTP response codes from 400-599 as well as issues like certificate errors)

--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -62,6 +62,8 @@ variables:
 # Chaos studio configuration
 - name: 'chaosExperimentDurationSeconds'
   value: 180
+- name: 'chaosStartDelay'
+  value: 300
 
 # Others
 - name: 'smokeTestRetryCount' # How many times a request in the smoke tests is retried before declared as failed (retries HTTP response codes from 400-599 as well as issues like certificate errors)

--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -41,13 +41,13 @@ variables:
 # Embedded load testing configuration
 # Make sure that these parameters are aligned with the loadtest-baseline.yaml
 - name: 'loadTestNumberOfWorkerNodes' # number of worker nodes
-  value: 10
+  value: '10'
 - name: 'loadTestDurationInSeconds' # load test duration
-  value: 600
+  value: '600'
 - name: 'loadTestNumberOfUsers' # number of simulated users in the load test
-  value: 500
+  value: '500'
 - name: 'loadTestUserSpawnRate' # load test spawn rate users / per second
-  value: 10
+  value: '10'
 
 # Microsoft Azure Load Test (MALT) configuration
 - name: 'azureLoadTestEngineInstances'

--- a/.ado/pipelines/templates/stages-chaos.yaml
+++ b/.ado/pipelines/templates/stages-chaos.yaml
@@ -8,10 +8,8 @@ parameters:
   - name: customPrefix
     type: string
   - name: testDurationSeconds
-    type: number
     default: 0
-  - name: loadTestStartSeconds
-    type: number
+  - name: startDelay
     default: 300
   - name: podFailure
     type: boolean
@@ -89,12 +87,12 @@ stages:
 
       # Sleep for the duration of the load test startup; this is a simple attempt to sync the start of both tests.
       - task: Bash@3
-        displayName: 'Sleep for ${{ parameters.loadTestStartSeconds }} seconds'
+        displayName: 'Sleep for ${{ parameters.startDelay }} seconds'
         inputs:
           targetType: 'inline'
           script: |
-                echo "Sleeping for ${{ parameters.loadTestStartSeconds }} seconds while the load test is starting..."
-                sleep ${{ parameters.loadTestStartSeconds }}
+                echo "Sleeping for ${{ parameters.startDelay }} seconds while the load test is starting..."
+                sleep ${{ parameters.startDelay }}
 
       - ${{ if eq(parameters.podFailure, 'true') }}:
         - task: AzureCLI@2

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -305,9 +305,9 @@ stages:
       parameters:
         stageName: 'deployChaosExperiments'
         customPrefix: '$(prefix)$(customSuffix)'
-        testDurationSeconds: 180 # Chaos test duration for each experiment
-        memoryStress: true # run Chaos Memory stress
-        cpuStress: true # run Chaos CPU stress
+        testDurationSeconds: $(chaosExperimentDurationSeconds) # Chaos test duration for each experiment
+        memoryStress: false # run Chaos Memory stress
+        cpuStress: false # run Chaos CPU stress
         podFailure: true # run Chaos Pod Killer
         dependsOn:
         - testingGlobalEndpoints

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -305,7 +305,7 @@ stages:
       parameters:
         stageName: 'deployChaosExperiments'
         customPrefix: '$(prefix)$(customSuffix)'
-        testDurationSeconds: $(chaosExperimentDurationSeconds) # Chaos test duration for each experiment
+        testDurationSeconds: '$(chaosExperimentDurationSeconds)' # Chaos test duration for each experiment
         memoryStress: false # run Chaos Memory stress
         cpuStress: false # run Chaos CPU stress
         podFailure: true # run Chaos Pod Killer

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -306,6 +306,7 @@ stages:
         stageName: 'deployChaosExperiments'
         customPrefix: '$(prefix)$(customSuffix)'
         testDurationSeconds: '$(chaosExperimentDurationSeconds)' # Chaos test duration for each experiment
+        startDelay: '$(chaosStartDelay)'
         memoryStress: false # run Chaos Memory stress
         cpuStress: false # run Chaos CPU stress
         podFailure: true # run Chaos Pod Killer


### PR DESCRIPTION
Bringing over the timings from the chaos demo to `main`.

Tested here: https://dev.azure.com/Mission-Critical/Online/_build/results?buildId=1405&view=results

In the load test run (which is not visible anymore) the timings were a bit off (test was shorter than expected, only 1 failure etc.), but the configuration was applied from the pipeline, so it might be something with the service or pipeline synchronization.