### PR TITLE
Drop inline parsing of global tf outputs

### DIFF
--- a/.ado/pipelines/azure-deploy-grafana.yaml
+++ b/.ado/pipelines/azure-deploy-grafana.yaml
@@ -86,7 +86,7 @@ stages:
       # Get the deployment output from the global resources. We need this for the FDID.
       - template: templates/steps-parse-terraform-output.yaml
         parameters:
-          workingDirectory:           '$(pipeline.workspace)/terraformOutputGlobalInfra'
+          workingDirectory: '$(pipeline.workspace)/terraformOutputGlobalInfra'
 
       # Get the full image name/tags from the artefact created during build
       - template: templates/steps-parse-containerimagename.yaml

--- a/.ado/pipelines/templates/jobs-container-build.yaml
+++ b/.ado/pipelines/templates/jobs-container-build.yaml
@@ -11,6 +11,10 @@ jobs:
 
   - download: current # download pipeline artifacts
 
+  - template: steps-parse-terraform-output.yaml # parse global configuration settings from terraform deployment output
+    parameters:
+      workingDirectory: '$(Pipeline.Workspace)/terraformOutputGlobalInfra'  # Global infra deploy output directory
+
   - task: AzureCLI@2
     displayName: 'Docker build and push ${{ parameters.containerImageName }}'
     retryCountOnTaskFailure: 1
@@ -19,13 +23,8 @@ jobs:
       scriptType: pscore
       scriptLocation: inlineScript
       inlineScript: |
-        # load json data from downloaded terraform artifact
-        $infraDeployOutput = Get-ChildItem $(Pipeline.Workspace)/terraformOutputGlobalInfra/*.json | Get-Content | ConvertFrom-JSON
 
-        $acrName = $infraDeployOutput.acr_name.value # Container Registry Name (from terraform output)
-        $acrUrl = $infraDeployOutput.acr_login_server.value # Container Registry Login Server (from terraform output)
-
-        echo "*** Retrieved Azure Container Registry Login Server $acrUrl (from terraformOutputGlobalInfra)"
+        echo "*** Retrieved Azure Container Registry Login Server $(acr_login_server) from Terraform deployment output"
 
         echo "*** DEBUG: Build.SourceBranch: $(Build.SourceBranch)"
         $sourceBranch = $("$(Build.SourceBranch)" -replace "refs/heads/", "")
@@ -35,7 +34,7 @@ jobs:
         $containerImageTag = "$containerImageTagBranch-$(Build.BuildId)" # the tag gets created from the branch name plus Build Id. E.g.: "main-1234"
         echo "*** DEBUG: Image tag: $containerImageTag"
 
-        $imageNameBase = "$acrUrl/${{ parameters.containerImageName }}"
+        $imageNameBase = "$(acr_login_server)/${{ parameters.containerImageName }}"
         $imageNameTagSpecific = "$($imageNameBase):$($containerImageTag)"
         $imageNameTagLatest = "$($imageNameBase):latest" # Additionally we also tag this image with latest
         echo "*** DEBUG: Container Image Name: $imageName"
@@ -44,10 +43,10 @@ jobs:
         cd ${{ parameters.workingDirectory }}
 
         # Login to ACR so we can later push to it
-        az acr login -n $acrName
+        az acr login -n $(acr_name)
 
         if ($LastExitCode -ne 0) {
-          throw "*** Error - could not log in to ACR $acrName"
+          throw "*** Error - could not log in to ACR $(acr_name)"
         }
 
         echo "*** Starting to build image $imageNameTagSpecific locally"
@@ -55,15 +54,15 @@ jobs:
                      -t $imageNameTagLatest `
                     --file ${{ parameters.containerImageDockerfile }} .
 
-        echo "*** Pushing image $imageNameTagSpecific to ACR $acrName"
+        echo "*** Pushing image $imageNameTagSpecific to ACR $(acr_name)"
         docker push $imageNameTagSpecific
 
-        echo "*** Pushing image $imageNameTagLatest to ACR $acrName"
+        echo "*** Pushing image $imageNameTagLatest to ACR $(acr_name)"
         docker push $imageNameTagLatest
 
         ###### As an alternative to building locally on the build agent, we could also build in the ACR itself. But often the build agent is faster
-        #echo "*** Starting image $imageNameTagSpecific build on ACR $acrUrl"
-        #az acr build --image $imageNameTagSpecific --image $imageNameTagLatest --registry $acrUrl `
+        #echo "*** Starting image $imageNameTagSpecific build on ACR $(acr_login_server)"
+        #az acr build --image $imageNameTagSpecific --image $imageNameTagLatest --registry $(acr_login_server)`
         #            --file ${{ parameters.containerImageDockerfile }} .
 
         # Write image name to file so we can publish it

--- a/.ado/pipelines/templates/jobs-init-sampledata.yaml
+++ b/.ado/pipelines/templates/jobs-init-sampledata.yaml
@@ -9,6 +9,10 @@ jobs:
 
     - download: current # download pipeline artifacts
 
+    - template: steps-parse-terraform-output.yaml # parse global configuration settings from terraform deployment output
+      parameters:
+        workingDirectory: '$(Pipeline.Workspace)/terraformOutputGlobalInfra'  # Global infra deploy output directory
+
     - task: PowerShell@2
       displayName: 'Import Sample Data'
       retryCountOnTaskFailure: 1
@@ -16,13 +20,8 @@ jobs:
         targetType: inline
         script: |
 
-          # load json data from downloaded terraform artifact
-          $globalInfraDeployOutput = Get-ChildItem $(Pipeline.Workspace)/terraformOutputGlobalInfra/*.json | Get-Content | ConvertFrom-JSON
-
+          # import and parse stamp terraform deployment outputs
           $releaseUnitInfraDeployOutput = Get-ChildItem $(Pipeline.Workspace)/terraformOutputReleaseUnitInfra/*.json | Get-Content | ConvertFrom-JSON
-
-          # Azure Front Door Header ID
-          $frontdoorHeaderId = $globalInfraDeployOutput.frontdoor_id_header.value
 
           $apiKey = $releaseUnitInfraDeployOutput.api_key.value
 
@@ -37,7 +36,7 @@ jobs:
           $testData =  Get-Content -Path "src/app/sampledata.json" | ConvertFrom-JSON
 
           $header = @{
-            "X-Azure-FDID" = "$frontdoorHeaderId"
+            "X-Azure-FDID" = "$(frontdoor_id_header)"
             "X-API-KEY" = "$apiKey"
           }
 

--- a/.ado/pipelines/templates/jobs-smoke-testing.yaml
+++ b/.ado/pipelines/templates/jobs-smoke-testing.yaml
@@ -42,12 +42,8 @@ jobs:
         scriptLocation: inlineScript
         inlineScript: |
 
-          # load json data from downloaded terraform artifact
-          $infraDeployOutput = Get-ChildItem $(Pipeline.Workspace)/terraformOutputGlobalInfra/*.json | Get-Content | ConvertFrom-JSON
-
           # Print Front Door Deployment details for troubleshooting and debugging purposes
-          $frontdoorResourceId = $infraDeployOutput.frontdoor_resource_id.value # Front Door Resource ID
-          $frontdoorResource = $(az resource show --id $frontdoorResourceId `
+          $frontdoorResource = $(az resource show --id $(frontdoor_resource_id) `
                                   --query '{enabledState:properties.enabledState,provisioningState:properties.provisioningState,resourceState:properties.resourceState}')
           $frontdoorState = $frontdoorResource | ConvertFrom-Json
 
@@ -80,25 +76,18 @@ jobs:
         targetType: inline
         script: |
 
-          # load json data from downloaded terraform artifact
-          $infraDeployOutput = Get-ChildItem $(Pipeline.Workspace)/terraformOutputGlobalInfra/*.json | Get-Content | ConvertFrom-JSON
-
-          # Azure Front Door Endpoint URI
-          $frontdoorFqdn = $infraDeployOutput.frontdoor_fqdn.value
-
           # We are using Playwright to browse the UI and capture screenshots
-
           # install Playwright dependencies
           echo "Installing Playwright dependencies..."
           npm install playwright-chromium @playwright/test -y
 
-          $env:TEST_BASEURL = "https://$frontDoorFqdn"
+          $env:TEST_BASEURL = "https://$(frontdoor_fqdn)"
           $env:SCREENSHOT_PATH = "$pwd/screenshots"
           $env:TEST_RUN_ALL_OPTIONAL_STEPS = "true"
 
           $playwrightTestPath = "src/testing/ui-test-playwright"
 
-          echo "*** Running PlayWright tests from $playwrightTestPath against https://$frontDoorFqdn"
+          echo "*** Running PlayWright tests from $playwrightTestPath against https://$(frontdoor_fqdn)"
 
           npx playwright test -c $playwrightTestPath --timeout 60000
 

--- a/.ado/pipelines/templates/jobs-smoke-testing.yaml
+++ b/.ado/pipelines/templates/jobs-smoke-testing.yaml
@@ -29,6 +29,10 @@ jobs:
 
     - download: current # download pipeline artifacts
 
+    - template: steps-parse-terraform-output.yaml
+      parameters:
+        workingDirectory: '$(Pipeline.Workspace)/terraformOutputGlobalInfra'  # Global infra deploy output directory
+
     - task: AzureCLI@2
       displayName: 'Verify global Front Foor state configuration'
       retryCountOnTaskFailure: 1

--- a/.ado/pipelines/templates/jobs-workload-deploy.yaml
+++ b/.ado/pipelines/templates/jobs-workload-deploy.yaml
@@ -58,6 +58,10 @@ jobs: # using jobs so they each run in parallel
 
     - template: steps-buildagent-prerequisites.yaml
 
+    - template: steps-parse-terraform-output.yaml
+      parameters:
+        workingDirectory: '$(Pipeline.Workspace)/terraformOutputGlobalInfra'  # Global infra deploy output directory
+
     - task: AzureCLI@2
       displayName: 'Install workload CatalogService on AKS clusters'
       retryCountOnTaskFailure: 2
@@ -72,13 +76,8 @@ jobs: # using jobs so they each run in parallel
           # load json data from downloaded terraform artifact
           $releaseUnitInfraDeployOutput = Get-ChildItem $(Pipeline.Workspace)/terraformOutputReleaseUnitInfra/*.json | Get-Content | ConvertFrom-JSON
 
-          $globalInfraDeployOutput = Get-ChildItem $(Pipeline.Workspace)/terraformOutputGlobalInfra/*.json | Get-Content | ConvertFrom-JSON
-
-          $frontDoorId = $globalInfraDeployOutput.frontdoor_id_header.value
-          echo "*** Retrieved Azure Front Door Header ID $frontDoorId"
-
-          $frontDoorFqdn = $globalInfraDeployOutput.frontdoor_fqdn.value
-          echo "*** Retrieved Azure Front Door FQDN $frontDoorFqdn"
+          echo "*** Retrieved Azure Front Door Header ID $(frontdoor_id_header) from Terraform output"
+          echo "*** Retrieved Azure Front Door FQDN $(frontdoor_fqdn) from Terraform output"
 
           # loop through stamps from pipeline artifact json
           foreach($stamp in $releaseUnitInfraDeployOutput.stamp_properties.value) {
@@ -107,9 +106,9 @@ jobs: # using jobs so they each run in parallel
 
             helm upgrade --install workload-catalogservice src/app/charts/catalogservice `
                          --namespace "$(workloadNamespace)" --create-namespace `
-                         --set azure.frontdoorid="$frontDoorId" `
+                         --set azure.frontdoorid="$(frontdoor_id_header)" `
                          --set azure.region="$region" `
-                         --set azure.baseurl="$frontDoorFqdn" `
+                         --set azure.baseurl="$(frontdoor_fqdn)" `
                          --set containerimage="$fullContainerImageName" `
                          --set workload.domainname="$fqdn" `
                          ${{ parameters.additionalHelmArguments }}
@@ -160,8 +159,6 @@ jobs: # using jobs so they each run in parallel
           # load json data from downloaded terraform artifact
           $releaseUnitInfraDeployOutput = Get-ChildItem $(Pipeline.Workspace)/terraformOutputReleaseUnitInfra/*.json | Get-Content | ConvertFrom-JSON
 
-          $globalInfraDeployOutput = Get-ChildItem $(Pipeline.Workspace)/terraformOutputGlobalInfra/*.json | Get-Content | ConvertFrom-JSON
-
           # loop through stamps from pipeline artifact json
           foreach($stamp in $releaseUnitInfraDeployOutput.stamp_properties.value) {
 
@@ -182,7 +179,7 @@ jobs: # using jobs so they each run in parallel
             # Apply workload BackgroundProcessor helm chart
             echo  "*** Deploy workload BackgroundProcessor to $aksClusterName (in $aksClusterResourceGroup) via helm chart"
             helm upgrade --install workload-backgroundprocessor src/app/charts/backgroundprocessor `
-                         --namespace $(workloadNamespace) --create-namespace `
+                         --namespace $(workloadNamespace) --create-namespace --wait `
                          --set containerimage="$fullContainerImageName" `
                          --set azure.region="$region" `
                          ${{ parameters.additionalHelmArguments }}

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -332,6 +332,10 @@ stages:
 
             - template: steps-buildagent-prerequisites.yaml # Install tools like kubectl
 
+            - template: steps-parse-terraform-output.yaml # parse global configuration settings from terraform deployment output
+              parameters:
+                workingDirectory: '$(Pipeline.Workspace)/terraformOutputGlobalInfra'  # Global infra deploy output directory
+
             - ${{ if ne(parameters.environment, 'e2e') }}: # Only in int/prod
               - task: AzureCLI@2
                 displayName: 'Fetch previous release prefix through disabled Front Door backends'
@@ -344,16 +348,11 @@ stages:
                     # We need the az CLI Front Door extension
                     az extension add --name front-door
 
-                    $globalInfraDeployOutput = Get-ChildItem $(Pipeline.Workspace)/terraformOutputGlobalInfra/*.json | Get-Content | ConvertFrom-JSON
-
-                    $rgName = $globalInfraDeployOutput.global_resource_group_name.value
-                    $fdName = $globalInfraDeployOutput.frontdoor_name.value
-
                     # Fetch disabled backends from the BackendApis pool. We only fetch the first one, assuming it represents all the stamps of the previous release unit
                     $disabledBackendAddress = $(az network front-door backend-pool backend list `
-                                      --front-door-name $fdName `
+                                      --front-door-name $(frontdoor_name) `
                                       --pool-name BackendApis `
-                                      --resource-group $rgName `
+                                      --resource-group $(global_resource_group_name) `
                                       --query "[?enabledState=='Disabled'].{address:address}[0]" -o tsv)
 
                     if($LastExitCode -ne 0)
@@ -397,11 +396,6 @@ stages:
                     # Setting oldReleasePrefix=prefix-customSuffix means that we target the same release unit that was deployed earlier by this very pipeline
                     echo "*** Setting pipeline variable oldReleasePrefix = $(prefix)$(customSuffix)"
                     echo "##vso[task.setvariable variable=oldReleasePrefix]$(prefix)$(customSuffix)"
-
-            - template: steps-parse-terraform-output.yaml
-              parameters:
-                workingDirectory: '$(Pipeline.Workspace)/terraformOutputGlobalInfra'  # Global infra deploy output directory
-
 
             # Delete all deployments in the workload namespace. This will make sure the application is not running anymore before we destroy the infrastructure in the next step.
             # This prevents side effects in the logging in which errors might show up which are only related to the destructions of the infra

--- a/.ado/pipelines/templates/steps-frontdoor-traffic-switch.yaml
+++ b/.ado/pipelines/templates/steps-frontdoor-traffic-switch.yaml
@@ -19,6 +19,10 @@ steps:
     terraformStateFilename:     '$(terraformStateFileGlobal)'
     terraformWorkingDirectory:  '$(workingDirectory)/globalresources'
 
+- template: steps-parse-terraform-output.yaml # parse global configuration settings from terraform deployment output
+  parameters:
+    workingDirectory: '$(Pipeline.Workspace)/terraformOutputGlobalInfra'  # Global infra deploy output directory
+
 - task: AzureCLI@2
   displayName: 'Create updated Front Door backend list'
   retryCountOnTaskFailure: 1
@@ -29,11 +33,6 @@ steps:
     inlineScript: |
       # We need the az CLI Front Door extension
       az extension add --name front-door
-
-      $globalInfraDeployOutput = Get-ChildItem $(Pipeline.Workspace)/terraformOutputGlobalInfra/*.json | Get-Content | ConvertFrom-JSON
-
-      $rgName = $globalInfraDeployOutput.global_resource_group_name.value
-      $fdName = $globalInfraDeployOutput.frontdoor_name.value
 
       $newBackendsWeight = ${{ parameters.trafficWeightNewBackends }}
       $oldBackendsWeight = 100 - $newBackendsWeight # since the weight for the new backends is a percentage, we substract from 100 to get the remaining weights for the old backends
@@ -98,14 +97,14 @@ steps:
 
         # Fetch existing backends in the pool from Front Door. We need the attributes "address", "weight" and "enabledState"
         $backends = $(az network front-door backend-pool backend list `
-                        --front-door-name $fdName `
+                        --front-door-name $(frontdoor_name) `
                         --pool-name $pool `
-                        --resource-group $rgName `
+                        --resource-group $(global_resource_group_name) `
                         --query "[$queryOptionEnabledOnly].{address:address,weight:weight,enabled:enabledState}")
 
         if($LastExitCode -ne 0)
         {
-            throw "*** Error on fetching existing backends from Front Door $fdName for pool $pool"
+            throw "*** Error on fetching existing backends from Front Door $(frontdoor_name) for pool $pool"
         }
 
         $jsonBackends = $backends | ConvertFrom-Json -NoEnumerate
@@ -174,15 +173,10 @@ steps:
       # We need the az CLI Front Door extension
       az extension add --name front-door
 
-      $globalInfraDeployOutput = Get-ChildItem $(Pipeline.Workspace)/terraformOutputGlobalInfra/*.json | Get-Content | ConvertFrom-JSON
-
-      $rgName = $globalInfraDeployOutput.global_resource_group_name.value
-      $fdName = $globalInfraDeployOutput.frontdoor_name.value
-
       echo "*** Purging Front Door cache with path /*"
-      az network front-door purge-endpoint -g $rgName -n $fdName --content-paths "/*"
+      az network front-door purge-endpoint -g $(global_resource_group_name) -n $(frontdoor_name) --content-paths "/*"
 
       if($LastExitCode -ne 0)
       {
-          throw "*** Error on purging cache in Front Door $fdName"
+          throw "*** Error on purging cache in Front Door $(frontdoor_name)"
       }


### PR DESCRIPTION
This PR replaces the in some parts of the pipeline used inline parsing of the global terraform deployment outputs with the automated parsing and publishing (as pipeline vars) via `steps-parse-terraform-output.yaml`.

```yaml
- template: steps-parse-terraform-output.yaml # parse global configuration settings from terraform deployment output
  parameters:
    workingDirectory: '$(Pipeline.Workspace)/terraformOutputGlobalInfra'  # Global infra deploy output directory
```

<img width="500" alt="image" src="https://user-images.githubusercontent.com/17407022/168269725-d5a3b00c-51ce-4674-bd9b-36182f1f638b.png">
