### PR TITLE
Rename the Cosmos key for consistency

### DIFF
--- a/src/app/AlwaysOn.Shared/Services/CosmosDbService.cs
+++ b/src/app/AlwaysOn.Shared/Services/CosmosDbService.cs
@@ -50,7 +50,7 @@ namespace AlwaysOn.Shared.Services
 
             _logger.LogInformation("Initializing Cosmos DB client with endpoint {endpoint} in ApplicationRegion {azureRegion}. Database name {databaseName}", sysConfig.CosmosEndpointUri, sysConfig.AzureRegion, sysConfig.CosmosDBDatabaseName);
 
-            CosmosClientBuilder clientBuilder = new CosmosClientBuilder(sysConfig.CosmosEndpointUri, sysConfig.CosmosApiKey)
+            CosmosClientBuilder clientBuilder = new CosmosClientBuilder(sysConfig.CosmosEndpointUri, sysConfig.CosmosKey)
                 .WithConnectionModeDirect()
                 .WithContentResponseOnWrite(false)
                 .WithRequestTimeout(TimeSpan.FromSeconds(sysConfig.ComsosRequestTimeoutSeconds))

--- a/src/app/AlwaysOn.Shared/SysConfiguration.cs
+++ b/src/app/AlwaysOn.Shared/SysConfiguration.cs
@@ -53,7 +53,7 @@ namespace AlwaysOn.Shared
         public string GlobalStorageAccountConnectionString => Configuration["GLOBAL_STORAGEACCOUNT_CONNECTIONSTRING"];
 
         public string CosmosEndpointUri => Configuration["COSMOSDB_ENDPOINT"];
-        public string CosmosApiKey => Configuration["COSMOSDB_APIKEY"];
+        public string CosmosKey => Configuration["COSMOSDB_KEY"];
         public string CosmosDBDatabaseName => Configuration["COSMOSDB_DATABASENAME"];
 
         public string FrontendSenderEventHubConnectionString => Configuration["FRONTEND_SENDEREVENTHUBCONNECTIONSTRING"];

--- a/src/infra/workload/releaseunit/modules/stamp/keyvault-secrets.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/keyvault-secrets.tf
@@ -14,7 +14,7 @@ locals {
     "APPLICATIONINSIGHTS-CONNECTION-STRING"      = data.azurerm_application_insights.stamp.connection_string
     "APPLICATIONINSIGHTS-ADAPTIVE-SAMPLING"      = var.ai_adaptive_sampling,
     "CosmosDb-Endpoint"                          = data.azurerm_cosmosdb_account.global.endpoint
-    "CosmosDb-ApiKey"                            = data.azurerm_cosmosdb_account.global.primary_key
+    "CosmosDb-Key"                            = data.azurerm_cosmosdb_account.global.primary_key
     "CosmosDb-DatabaseName"                      = var.cosmosdb_database_name
     "API-Key"                                    = var.api_key
   }


### PR DESCRIPTION
Based on our initial discussion, the Cosmos DB configuration key should follow our naming standards.

https://dev.azure.com/Mission-Critical/Online/_build/results?buildId=1511