### PR TITLE
Use relative URL in response `Location` header of the CatalogService

### DIFF
--- a/.ado/pipelines/templates/jobs-workload-deploy.yaml
+++ b/.ado/pipelines/templates/jobs-workload-deploy.yaml
@@ -75,7 +75,6 @@ jobs: # using jobs so they each run in parallel
           $releaseUnitInfraDeployOutput = Get-ChildItem $(Pipeline.Workspace)/terraformOutputReleaseUnitInfra/*.json | Get-Content | ConvertFrom-JSON
 
           echo "*** Retrieved Azure Front Door Header ID $(frontdoor_id_header) from Terraform output"
-          echo "*** Retrieved Azure Front Door FQDN $(frontdoor_fqdn) from Terraform output"
 
           # loop through stamps from pipeline artifact json
           foreach($stamp in $releaseUnitInfraDeployOutput.stamp_properties.value) {
@@ -107,7 +106,6 @@ jobs: # using jobs so they each run in parallel
                          --create-namespace `
                          --set azure.frontdoorid="$(frontdoor_id_header)" `
                          --set azure.region="$region" `
-                         --set azure.baseurl="$(frontdoor_fqdn)" `
                          --set containerimage="$fullContainerImageName" `
                          --set workload.domainname="$fqdn" `
                          --wait

--- a/.ado/scripts/SmokeTest.ps1
+++ b/.ado/scripts/SmokeTest.ps1
@@ -128,12 +128,10 @@ foreach($target in $targets) {
   Start-Sleep 10
 
   # The 202-response to POST new comment contains in the 'Location' header the URL under which the new comment will be accessible
-  $getCommentUrl = $responsePostComment.Headers['Location'][0]
+  $getCommentPath = $responsePostComment.Headers['Location'][0]
 
-  if ($mode -eq "stamp") {
-    # The Location header contains the global FQDN of the Front Door entry point. For the the individual cluster, we need to change the URL
-    $getCommentUrl = $getCommentUrl -replace $frontdoorFqdn,$targetFqdn
-  }
+  # The location header does not contain the host part of the URL so we need to prepend it
+  $getCommentUrl = "$($targetFqdn)$($getCommentPath)"
 
   Write-Output "*** Call - Get newly created comment ($mode)"
   Invoke-WebRequestWithRetry -Uri $getCommentUrl -Method 'GET' -Headers $header -MaximumRetryCount $smokeTestRetryCount -RetryWaitSeconds $smokeTestRetryWaitSeconds

--- a/src/app/AlwaysOn.CatalogService/Startup.cs
+++ b/src/app/AlwaysOn.CatalogService/Startup.cs
@@ -142,7 +142,7 @@ namespace AlwaysOn.CatalogService
                         // This is to simplify the reverse-proxy setup in front of the application
                         try
                         {
-                            if (context.Response.Headers.Location.Count == 1)
+                            if (!string.IsNullOrEmpty(context.Response.Headers.Location))
                             {
                                 var locationUrl = new Uri(context.Response.Headers.Location);
                                 context.Response.Headers.Location = locationUrl.PathAndQuery;

--- a/src/app/AlwaysOn.CatalogService/Startup.cs
+++ b/src/app/AlwaysOn.CatalogService/Startup.cs
@@ -15,10 +15,12 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Primitives;
 using Microsoft.OpenApi.Models;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -141,6 +143,17 @@ namespace AlwaysOn.CatalogService
                 {
                     if (o is HttpContext ctx)
                     {
+                        // In order to get relative location headers (without the host part), we modify any location header here
+                        // This is to simplify the reverse-proxy setup in front of the application
+                        IHeaderDictionary headers = context.Response.Headers;
+                        if (headers.TryGetValue("location", out StringValues locationHeaderValue))
+                        {
+                            var locationUrl = new Uri(locationHeaderValue.FirstOrDefault());
+
+                            context.Response.Headers.Remove("location");
+                            context.Response.Headers.Add("location", locationUrl.PathAndQuery);
+                        }
+
                         context.Response.Headers.Add("X-Server-Name", Environment.MachineName);
                         context.Response.Headers.Add("X-Server-Location", sysConfig.AzureRegion);
                         context.Response.Headers.Add("X-Correlation-ID", Activity.Current?.RootId);

--- a/src/app/AlwaysOn.CatalogService/Startup.cs
+++ b/src/app/AlwaysOn.CatalogService/Startup.cs
@@ -142,7 +142,7 @@ namespace AlwaysOn.CatalogService
                         // This is to simplify the reverse-proxy setup in front of the application
                         try
                         {
-                            if (context.Response.Headers.Location.Count > 0)
+                            if (context.Response.Headers.Location.Count == 1)
                             {
                                 var locationUrl = new Uri(context.Response.Headers.Location);
                                 context.Response.Headers.Location = locationUrl.PathAndQuery;

--- a/src/app/charts/catalogservice/templates/ingress.yaml
+++ b/src/app/charts/catalogservice/templates/ingress.yaml
@@ -11,15 +11,8 @@ metadata:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "120"   #  Set timeout to read from the backend pods to 120s. Cosmos DB retries can go up to 60s
     nginx.ingress.kubernetes.io/use-regex: "true"
-    # Optionally, we could rewrite taret path to remove the name of the service. However, this might break some things like Location header rewrites for the response
+    # Optionally, we could rewrite taret path to remove the name of the service. However, this might break some things like Location header for the response
     # nginx.ingress.kubernetes.io/rewrite-target: /$2
-
-    # Rewrite for the Location response header. Replaces the internal FQDN of the cluster with the base URL of the environment
-    # Docs: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#proxy-redirect
-    # Backend header might look like this: http://adaptedanteater-cluster.northeurope.cloudapp.azure.com/api/1.0/catalogitem/123
-    # Will be rewritte to something like https://aoint-app.alwaysonapp.net/api/1.0/catalogitem/123
-    nginx.ingress.kubernetes.io/proxy-redirect-from: "~^((http|https)://.+?)/(.+)$"
-    nginx.ingress.kubernetes.io/proxy-redirect-to: "https://{{ .Values.azure.baseurl }}/$3"
   {{- if .Values.azure.frontdoorid }}
     # To restric traffic coming only through our Front Door instance, we use a header check on the X-Azure-FDID
     # The value gets injected by the pipeline. Hence, this ID should be treated as a senstive value

--- a/src/app/charts/catalogservice/values.yaml
+++ b/src/app/charts/catalogservice/values.yaml
@@ -24,7 +24,6 @@ networkPolicy:
 azure:
   frontdoorid: "" # Azure Front Door Header ID (blank = disabled)
   region: "East US 2"
-  baseurl: "OVERWRITE.myalwaysonapp.net" # FQDN used by the Azure Front Door endpoint
 
 healthservice:
   name: "healthservice-service" # name of the healthservice service in k8s


### PR DESCRIPTION
This adds some middleware into the catalogservice to make `Location` response headers (e.g for 201-Created or 202-Accepted) relative instead of absolute URLs. This removes the need for extra handling in the reverse proxies