### PR TITLE
[Docs] Split up getting started guide into portal and CLI experiences

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,8 @@
 ## Azure Mission-Critical Reference Implementation Guide
 
 - [Overview](./reference-implementation/README.md)
-- [Getting Started](./reference-implementation/Getting-Started.md)
+- [Getting started](./reference-implementation/Getting-Started.md)
+  - [Getting Started using CLI](./reference-implementation/Getting-Started-CLI.md)
 - [Frequently Asked Questions (FAQs)](./reference-implementation/FAQ.md)
 - [Critical Design Areas](./reference-implementation/README.md#Critical-Design-Areas)
   - Application Design

--- a/docs/reference-implementation/Getting-Started-CLI.md
+++ b/docs/reference-implementation/Getting-Started-CLI.md
@@ -2,7 +2,7 @@
 
 This step-by-step guide describes the process to deploy Azure Mission-Critical in your own environment from the beginning. At the end of this guide you will have an Azure DevOps organization and project set up to deploy a copy of the Azure Mission-Critical reference implementation into an Azure Subscription.
 
-**This guide describes the steps to get started using the (Azure DevOps) CLI only. To create the set up through the Portal (UI) follow [this guide](./Getting-Started.md) instead.**
+**This guide describes the steps to get started using the Azure CLI only. To create the set up through the Portal (UI) follow [this guide](./Getting-Started.md) instead.**
 
 ## How to deploy?
 
@@ -31,8 +31,8 @@ The following must be installed on the client machine used to deploy Azure Missi
 
 The process to deploy Azure Mission-Critical is comprised of the following steps:
 
-1) Create an [Azure DevOps organization and project](#create-a-new-azure-devops-project)
-1) Generate your own repository based on the [Azure Mission-Critical GitHub template](https://github.com/Azure/Mission-Critical-Online/generate) repository
+1) Create an [Azure DevOps organization and project](#1-create-a-new-azure-devops-organization-and-project)
+1) Generate your own repository based on the Azure Mission-Critical [GitHub template](#2-generate-your-own-repository-based-on-the-azure-mission-critical-github-template) repository
 1) Import [deployment pipelines](#3-import-deployment-pipelines)
 1) Create [Service Principals](#4-create-azure-service-principal) for each individual Azure subscription
 1) Create [Service Connections](#5-create-azure-service-connections) in Azure DevOps
@@ -80,7 +80,7 @@ az devops configure --defaults organization=https://dev.azure.com/<your-org> pro
 
 Azure DevOps Repos would allow us to import the Azure Mission-Critical reference implementation GitHub repository into Azure DevOps as well. For this guide we have decided to generate our own repository based on the template on GitHub and use it from there.
 
-Sign into GitHub and go to the root of the Azure Mission-Critical reference implementation repository on GitHub and click on "Use this template" in the top right corner':
+Sign into GitHub and go to the root of the Azure Mission-Critical reference implementation repository on GitHub and click on [Use this template](https://github.com/Azure/Mission-Critical-Online/generate) in the top right corner':
 
 ![Use GitHub Repo template](/docs/media/GettingStarted-template.png)
 

--- a/docs/reference-implementation/Getting-Started-CLI.md
+++ b/docs/reference-implementation/Getting-Started-CLI.md
@@ -262,7 +262,7 @@ You can now go to the Azure Portal and check the provisioned resources. In the R
 
 We can now browse to the demo app website. Fetch the URL from the Front Door resource:
 
-1) Find the "Global Resource" group, e.g. `<myprefix>123-global-fd`
+1) Find the "Global Resource" group (e.g. `<myprefix>123-global-fd`)
 1) Click on the Front Door resource (e.g. `<myprefix>123-global-fd`)
 1) Click on the "Frontend host" link
 ![Frontend host](/docs/media/frontdoor-resource-hostlink.png)

--- a/docs/reference-implementation/Getting-Started-CLI.md
+++ b/docs/reference-implementation/Getting-Started-CLI.md
@@ -1,8 +1,8 @@
-# Getting started
+# Getting started using CLI
 
 This step-by-step guide describes the process to deploy Azure Mission-Critical in your own environment from the beginning. At the end of this guide you will have an Azure DevOps organization and project set up to deploy a copy of the Azure Mission-Critical reference implementation into an Azure Subscription.
 
-**This guide describes the steps to get started using the Azure DevOps Portal (UI) only. To create the set up through the Azure DevOps CLI follow [this guide](./Getting-Started-CLI.md) instead.**
+**This guide describes the steps to get started using the (Azure DevOps) CLI only. To create the set up through the Portal (UI) follow [this guide](./Getting-Started.md) instead.**
 
 ## How to deploy?
 
@@ -21,9 +21,11 @@ The Azure Mission-Critical reference implementation gets deployed into an Azure 
 - Either your user needs to have **Owner** or **User Access Administrator (UAA)** permission and you have **the right to create new Service Principals** on your Azure AD tenant, or
 - You need to have a pre-provisioned Service Principal with Owner permissions on the subscription
 
-The following must be installed on the client machine used to deploy Azure Mission-Critical reference implementation:
+The following must be installed on the client machine used to deploy Azure Mission-Critical reference implementation using this guide:
 
 - [Azure CLI](https://docs.microsoft.com/cli/azure/service-page/azure%20cli?view=azure-cli-latest)
+- [Azure DevOps CLI](https://docs.microsoft.com/azure/devops/cli/?view=azure-devops)
+- [PowerShell](https://docs.microsoft.com/powershell/scripting/install/installing-powershell?view=powershell-7.1) (on Windows, Linux or macOS).
 
 ## Overview
 
@@ -46,17 +48,33 @@ To deploy the Azure Mission-Critical reference implementation, you need to creat
 
 - [Create an organization or project collection](https://docs.microsoft.com/azure/devops/organizations/accounts/create-organization?view=azure-devops)
 
+> **Important!** The [Azure DevOps CLI](https://docs.microsoft.com/azure/devops/cli/?view=azure-devops) is used for the subsequent steps. Please make sure that it is installed. The authentication is done via a Personal Access Token (PAT). This can be done via `az devops login` or by storing the PAT token in the `AZURE_DEVOPS_EXT_PAT` environment variable.  The token is expected to have at least the following scopes: `Agent Pools`: Read & manage, `Build`: Read & execute, `Project and Team`: Read, write, & manage, `Service Connections`: Read, query, & manage.
 
 #### Create a new Azure DevOps project
 
-Once you have created an Azure DevOps organization, you can create a new project in that organization. Go to the Azure DevOps portal, select the desired Organization and Click on "+ New Project" in the upper right hand corner.
+When using Azure DevOps CLI, make sure that the [Azure DevOps CLI](https://docs.microsoft.com/azure/devops/cli/?view=azure-devops) is configured to use the Azure DevOps organization that was created in the previous task.
 
-Select a name and set the visibility. Both "Enterprise" or "Private" are fine for this walkthrough.
+```powershell
+$env:AZURE_DEVOPS_EXT_PAT="<azure-devops-personal-access-token>"
+
+# set the org context
+az devops configure --defaults organization=https://dev.azure.com/<your-org>
+
+# create a new project
+az devops project create --name <your-project>
+```
+
+> `AZURE_DEVOPS_EXT_PAT` is used for automation purposes. If not set, `az devops login` will prompt you for the Personal Access Token (PAT).
 
 This will result in a new project, `<your-project>` in your Azure DevOps organization:
 
 ![New ADO Project](/docs/media/AlwaysOnGettingStarted1.png)
 
+For all the subsequent tasks done via `az devops` or `az pipelines` the context can be set via:
+
+```powershell
+az devops configure --defaults organization=https://dev.azure.com/<your-org> project=<your-project>
+```
 
 ### 2) Generate your own repository based on the Azure Mission-Critical GitHub template
 
@@ -72,6 +90,8 @@ This will let you create a repository in your own account or organization. This 
 
 Now that you have your own repo, let's start to import the pre-created pipelines into Azure Pipelines.
 
+> **You will need to import each Pipeline YAML file individually. But we will only import the E2E pipeline to start with.**
+
 The files to import are the YAML files stored in the `/.ado/pipelines/` directory. **Do not** import files from subdirectories, such as `/.ado/pipelines/config/` or `/.ado/pipelines/templates/`, or from other directories in the repo.
 
 You can find more details about any of the pipelines within the [pipelines documentation](/.ado/pipelines/README.md).
@@ -85,36 +105,31 @@ When you are later ready to also deploy further environments such as INT (integr
 - `/.ado/pipelines/azure-release-int.yaml`
 - `/.ado/pipelines/azure-release-prod.yaml`
 
-#### Import in Azure DevOps Portal
+#### Import via Azure DevOps CLI
 
-> **Important!** The Import Pipeline UI will ask you to approve needed permissions, and will show you a list of all YAML files found within the repository. See note above about which YAML files to import.
+Using the `az devops` / `az pipelines` CLI:
 
-1) Go to your Azure DevOps project
-1) Go to "Pipelines"
-1) Click "Create pipeline" or "New pipeline"
-1) Select "GitHub (YAML)"
+> Note: If you are using Azure DevOps Repos instead of GitHub, change `--repository-type github` to `--repository-type tfsgit` in the command below. Also, if your branch is not called `main` but, for example, `master` change this accordingly.
 
-   > **Note!** If requested, grant the Azure Pipelines app permissions to access your GitHub repository.
+First, you need to create a PAT (personal access token) on GitHub to use with ADO. This is required to be able to import the pipelines. For this, create a new token [here](https://github.com/settings/tokens). Select `repo` as the scope.
 
-   ![github authorization](/docs/media/github-ado-auth-1.png)
+Save the token securely. Then, set it as an environment variable in your shell:
 
-1) Search for your repository in "Select a repository" (name of your template)
+```powershell
+$env:AZURE_DEVOPS_EXT_GITHUB_PAT=<your PAT>
+```
 
-   > **Note!** If requested, grant the Azure Pipelines app permissions to access your GitHub repository.
+Now your session is authenticated and the ADO CLI will be able to import the pipelines from GitHub.
 
-1) Select "Existing Azure Pipelines YAML file" in the "Configure your pipeline" dialog and click "Continue"
+```powershell
+# set the org/project context
+az devops configure --defaults organization=https://dev.azure.com/<your-org> project=<your-project>
 
-   > **Note!** In the "Select an existing YAML file" dialog, select the YAML file you want to import. For the e2e pipeline this is `/.ado/pipelines/azure-release-e2e.yaml`.
-
-   ![select yaml pipline](/docs/media/AlwaysOnGettingStarted2Pipeline_select_yaml_pipeline.png)
-
-1) Select "Save" (from the dropdown menu under the "Run" button) to save the pipeline
-
-   ![Run or save Pipeline](/docs/media/AlwaysOnGettingStarted2RunOrSavePipeline.png 'Run or save Pipeline')
-
-1) Rename the pipeline by clicking on the three dots and (optionally) move it into a folder (see below).  The UI usually doesn't immediately reflect the change, so just refresh the page.
-
-   ![Rename/move pipeline](/docs/media/AlwaysOnGettingStarted2PipelineRename.png 'Rename/move pipeline')
+# import a YAML pipeline
+az pipelines create --name "Azure.AlwaysOn E2E Release" --description "Azure.AlwaysOn E2E Release" `
+                    --branch main --repository https://github.com/<your-template>/ --repository-type github `
+                    --skip-first-run true --yaml-path "/.ado/pipelines/azure-release-e2e.yaml"
+```
 
 ### 4) Create Azure Service Principal
 
@@ -164,16 +179,24 @@ Our Azure Mission-Critical reference implementation knows three different enviro
 
 These service connections can be created in the Azure DevOps Portal or via the `az devops` CLI. Create them using either one of these two methods. Make sure that you specify the right credentials for the **service principal created earlier**.
 
-#### Use Azure DevOps Portal
+#### Use Azure DevOps CLI
 
-1) Go to "Project settings" in Azure DevOps Portal
-1) Go to "Service connections" in the "Pipelines" section
-1) Click on "New service connection"
-1) Select "Azure Resource Manager"
-1) Select "Service principal (manual)"
-1) Set the subscription details and credentials
-1) Set the service connection name to one of the three above
-1) Click on "Verify and save"
+```powershell
+# set the org/project context
+az devops configure --defaults organization=https://dev.azure.com/<your-org> project=<your-project>
+
+$env:AZURE_DEVOPS_EXT_AZURE_RM_SERVICE_PRINCIPAL_KEY="<service-principal-password>"
+
+# create a new service connection
+az devops service-endpoint azurerm create `
+    --name alwayson-e2e-serviceconnection `
+    --azure-rm-tenant-id <tenant-id> `
+    --azure-rm-service-principal-id <app-id> `
+    --azure-rm-subscription-id <subscription-id> `
+    --azure-rm-subscription-name <subscription-name>
+```
+
+> `AZURE_DEVOPS_EXT_AZURE_RM_SERVICE_PRINCIPAL_KEY` is used for automation purposes. If not set, `az devops` will prompt you for the service principal password. See [az devops service-endpoint azurerm](https://docs.microsoft.com/cli/azure/devops/service-endpoint/azurerm?view=azure-cli-latest) for more information about parameters and options.
 
 ### 6) Adjust configuration
 
@@ -193,7 +216,6 @@ Modify the respective file for the environment which you want to deploy. At leas
 **After modifying the file, make sure to commit and push the changes to your Git repository.**
 
 For more details on the variables, you can consult [this guide](/.ado/pipelines/README.md#configuration-files).
-
 
 ### 7) Execute the first deployment
 

--- a/docs/reference-implementation/Getting-Started-CLI.md
+++ b/docs/reference-implementation/Getting-Started-CLI.md
@@ -165,7 +165,7 @@ More information about the required permissions needed to deploy via Terraform c
 
 ### 5) Create Azure Service Connections
 
-Our Azure Mission-Critical reference implementation knows three different environments: prod, int and e2e. These three environments can be selected for each individual pipeline run and can refer to the same or different (recommended) Azure subscriptions for proper separation. These environments are represented by service connections in Azure DevOps:
+The Azure Mission-Critical reference implementation knows three different environments: prod, int and e2e. These three environments can be selected for each individual pipeline run and can refer to the same or different (recommended) Azure subscriptions for proper separation. These environments are represented by service connections in Azure DevOps:
 
 > **Important!** Since these connection names are used in pipelines, use them exactly as specified below. If you change the name of the service connection, you have to also change it in pipeline YAML.
 

--- a/docs/reference-implementation/Getting-Started-CLI.md
+++ b/docs/reference-implementation/Getting-Started-CLI.md
@@ -52,7 +52,7 @@ To deploy the Azure Mission-Critical reference implementation, you need to creat
 
 #### Create a new Azure DevOps project
 
-When using Azure DevOps CLI, make sure that the [Azure DevOps CLI](https://docs.microsoft.com/azure/devops/cli/?view=azure-devops) is configured to use the Azure DevOps organization that was created in the previous task.
+Make sure that [Azure DevOps CLI](https://docs.microsoft.com/azure/devops/cli/?view=azure-devops) is configured to use the Azure DevOps organization that was created in the previous task.
 
 ```powershell
 $env:AZURE_DEVOPS_EXT_PAT="<azure-devops-personal-access-token>"

--- a/docs/reference-implementation/Getting-Started-CLI.md
+++ b/docs/reference-implementation/Getting-Started-CLI.md
@@ -131,6 +131,8 @@ az pipelines create --name "Azure.AlwaysOn E2E Release" --description "Azure.Alw
 
 ### 4) Create Azure Service Principal
 
+> This step can be skipped if a Service Principal was pre-provisioned.
+
 All pipelines require an Azure DevOps service connection to access the target Azure Subscription where the resources are deployed. These service connections use Service Principals to access Azure which can be configured automatically, when proper access is given, or manually in Azure DevOps by providing a pre-created Azure Service Principal with the required permissions.
 
 > **Important!** The AAD Service Principal needs **subscription-level owner permissions** as the pipeline will create various role assignments.

--- a/docs/reference-implementation/Getting-Started-CLI.md
+++ b/docs/reference-implementation/Getting-Started-CLI.md
@@ -80,7 +80,7 @@ az devops configure --defaults organization=https://dev.azure.com/<your-org> pro
 
 Azure DevOps Repos would allow us to import the Azure Mission-Critical reference implementation GitHub repository into Azure DevOps as well. For this guide we have decided to generate our own repository based on the template on GitHub and use it from there.
 
-Sign into GitHub and go to the root of the Azure Mission-Critical reference implementation repository on GitHub and click on [Use this template](https://github.com/Azure/Mission-Critical-Online/generate) in the top right corner':
+Sign into GitHub and go to the root of the Azure Mission-Critical reference implementation repository on GitHub and click on [Use this template](https://github.com/Azure/Mission-Critical-Online/generate) in the top right corner:
 
 ![Use GitHub Repo template](/docs/media/GettingStarted-template.png)
 

--- a/docs/reference-implementation/Getting-Started-CLI.md
+++ b/docs/reference-implementation/Getting-Started-CLI.md
@@ -105,7 +105,6 @@ When you are later ready to also deploy further environments such as INT (integr
 - `/.ado/pipelines/azure-release-int.yaml`
 - `/.ado/pipelines/azure-release-prod.yaml`
 
-#### Import via Azure DevOps CLI
 
 Using the `az devops` / `az pipelines` CLI:
 
@@ -177,9 +176,7 @@ Our Azure Mission-Critical reference implementation knows three different enviro
 
 > If you only created one Service Principal above, you only need to create one Service Connection for now.
 
-These service connections can be created in the Azure DevOps Portal or via the `az devops` CLI. Create them using either one of these two methods. Make sure that you specify the right credentials for the **service principal created earlier**.
-
-#### Use Azure DevOps CLI
+When you create the service connections, make sure that you specify the right credentials for the **service principal created earlier**.
 
 ```powershell
 # set the org/project context

--- a/docs/reference-implementation/Getting-Started.md
+++ b/docs/reference-implementation/Getting-Started.md
@@ -21,9 +21,7 @@ The Azure Mission-Critical reference implementation gets deployed into an Azure 
 - Either your user needs to have **Owner** or **User Access Administrator (UAA)** permission and you have **the right to create new Service Principals** on your Azure AD tenant, or
 - You need to have a pre-provisioned Service Principal with Owner permissions on the subscription
 
-The following must be installed on the client machine used to deploy Azure Mission-Critical reference implementation:
-
-- [Azure CLI](https://docs.microsoft.com/cli/azure/service-page/azure%20cli?view=azure-cli-latest)
+If you will create the Service Principal yourself, it is recommended to have either [Azure CLI](https://docs.microsoft.com/cli/azure/service-page/azure%20cli?view=azure-cli-latest) installed on your machine or have access to it through the [Azure Cloud Shell](https://docs.microsoft.com/azure/cloud-shell/).
 
 ## Overview
 

--- a/docs/reference-implementation/Getting-Started.md
+++ b/docs/reference-implementation/Getting-Started.md
@@ -116,6 +116,8 @@ When you are later ready to also deploy further environments such as INT (integr
 
 ### 4) Create Azure Service Principal
 
+> This step can be skipped if a Service Principal was pre-provisioned.
+
 All pipelines require an Azure DevOps service connection to access the target Azure Subscription where the resources are deployed. These service connections use Service Principals to access Azure which can be configured automatically, when proper access is given, or manually in Azure DevOps by providing a pre-created Azure Service Principal with the required permissions.
 
 > **Important!** The AAD Service Principal needs **subscription-level owner permissions** as the pipeline will create various role assignments.

--- a/docs/reference-implementation/Getting-Started.md
+++ b/docs/reference-implementation/Getting-Started.md
@@ -29,8 +29,8 @@ The following must be installed on the client machine used to deploy Azure Missi
 
 The process to deploy Azure Mission-Critical is comprised of the following steps:
 
-1) Create an [Azure DevOps organization and project](#create-a-new-azure-devops-project)
-1) Generate your own repository based on the [Azure Mission-Critical GitHub template](https://github.com/Azure/Mission-Critical-Online/generate) repository
+1) Create an [Azure DevOps organization and project](#1-create-a-new-azure-devops-organization-and-project)
+1) Generate your own repository based on the Azure Mission-Critical [GitHub template](#2-generate-your-own-repository-based-on-the-azure-mission-critical-github-template) repository
 1) Import [deployment pipelines](#3-import-deployment-pipelines)
 1) Create [Service Principals](#4-create-azure-service-principal) for each individual Azure subscription
 1) Create [Service Connections](#5-create-azure-service-connections) in Azure DevOps
@@ -62,7 +62,7 @@ This will result in a new project, `<your-project>` in your Azure DevOps organiz
 
 Azure DevOps Repos would allow us to import the Azure Mission-Critical reference implementation GitHub repository into Azure DevOps as well. For this guide we have decided to generate our own repository based on the template on GitHub and use it from there.
 
-Sign into GitHub and go to the root of the Azure Mission-Critical reference implementation repository on GitHub and click on "Use this template" in the top right corner':
+Sign into GitHub and go to the root of the Azure Mission-Critical reference implementation repository on GitHub and click on [Use this template](https://github.com/Azure/Mission-Critical-Online/generate) in the top right corner':
 
 ![Use GitHub Repo template](/docs/media/GettingStarted-template.png)
 

--- a/docs/reference-implementation/Getting-Started.md
+++ b/docs/reference-implementation/Getting-Started.md
@@ -162,7 +162,7 @@ Our Azure Mission-Critical reference implementation knows three different enviro
 
 > If you only created one Service Principal above, you only need to create one Service Connection for now.
 
-These service connections can be created in the Azure DevOps Portal or via the `az devops` CLI. Create them using either one of these two methods. Make sure that you specify the right credentials for the **service principal created earlier**.
+When you create the service connections, make sure that you specify the right credentials for the **service principal created earlier**.
 
 #### Use Azure DevOps Portal
 

--- a/docs/reference-implementation/Getting-Started.md
+++ b/docs/reference-implementation/Getting-Started.md
@@ -2,7 +2,7 @@
 
 This step-by-step guide describes the process to deploy Azure Mission-Critical in your own environment from the beginning. At the end of this guide you will have an Azure DevOps organization and project set up to deploy a copy of the Azure Mission-Critical reference implementation into an Azure Subscription.
 
-**This guide describes the steps to get started using the Azure DevOps Portal (UI) only. To create the set up through the Azure DevOps CLI follow [this guide](./Getting-Started-CLI.md) instead.**
+**This guide describes the steps to get started using the Azure DevOps Portal (UI) only. To create the set up through the Azure CLI only follow [this guide](./Getting-Started-CLI.md) instead.**
 
 ## How to deploy?
 

--- a/docs/reference-implementation/OpProcedures-Operational-Procedures.md
+++ b/docs/reference-implementation/OpProcedures-Operational-Procedures.md
@@ -39,14 +39,7 @@ This will surface any traces, metrics and dependency calls that were made as par
 
 ## Transient Pipeline Failures
 
-There are some points in the deployment pipeline which tend to create transient failures. For most of them, a simple **re-run of the failed job fixes the issue.** No need to re-run the entire pipeline. When the failed job succeeds in a retry, all subsequent steps will also be executed.
-A couple of examples which were observed so far:
-
-- Terraform `init` failing after 1 second with no apparent error message
-- Terraform `init` failing with an authorization error against the backend storage account
-- Deployment of one of the workloads on AKS failing after many retry attempts (mostly the CatalogService)
-- Terraform deployment of Azure Monitor saved queries failing with a Bad Request error
-- Download of some dependency, e.g. Terraform CLI or Helm
+See [Troubleshooting](Troubleshooting.md) for more details about known, transient pipeline issues.
 
 ## Package / Dependency updates
 

--- a/docs/reference-implementation/README.md
+++ b/docs/reference-implementation/README.md
@@ -62,6 +62,7 @@ As with the Azure Mission-Critical Design Guidelines, the Reference Implementati
 ## Helpful Information
 
 - [Getting started](Getting-Started.md) outlines the process and required steps to deploy Azure Mission-Critical in your environment, including preparing Azure DevOps pipelines. It should be read in tandem with the Reference Implementation guidance.
+- [Getting started using CLI](Getting-Started-CLI.md) - same as the guide above but contains instructions on how to create the setup using CLI instead of the ADO portal experience.
 - [SLO and Availability](AppDesign-SLO-Availability.md) outlines the SLO for Azure Mission-Critical (99.95%) and how this figure was calculated.
 - [ESLZ Alignment](ESLZ-Alignment.md) outlines how Azure Mission-Critical aligns with and compliments the Enterprise Scale Landing Zones.
 - [Troubleshooting](Troubleshooting.md) collects solutions to known issues during development and deployment.

--- a/docs/reference-implementation/README.md
+++ b/docs/reference-implementation/README.md
@@ -62,7 +62,7 @@ As with the Azure Mission-Critical Design Guidelines, the Reference Implementati
 ## Helpful Information
 
 - [Getting started](Getting-Started.md) outlines the process and required steps to deploy Azure Mission-Critical in your environment, including preparing Azure DevOps pipelines. It should be read in tandem with the Reference Implementation guidance.
-- [Getting started using CLI](Getting-Started-CLI.md) - same as the guide above but contains instructions on how to create the setup using CLI instead of the ADO portal experience.
+  - [Getting started using CLI](Getting-Started-CLI.md) - same as the guide above but contains instructions on how to create the setup using CLI instead of the ADO portal experience.
 - [SLO and Availability](AppDesign-SLO-Availability.md) outlines the SLO for Azure Mission-Critical (99.95%) and how this figure was calculated.
 - [ESLZ Alignment](ESLZ-Alignment.md) outlines how Azure Mission-Critical aligns with and compliments the Enterprise Scale Landing Zones.
 - [Troubleshooting](Troubleshooting.md) collects solutions to known issues during development and deployment.


### PR DESCRIPTION
As discussed internally, to keep the main getting started guide a bit easier to look at, I split up the CLI instructions into another doc