### PR TITLE
Adding AKS user node pool

### DIFF
--- a/src/app/charts/backgroundprocessor/templates/deployment.yaml
+++ b/src/app/charts/backgroundprocessor/templates/deployment.yaml
@@ -56,6 +56,13 @@ spec:
             mountPath: "/tmp"
           - name: var-log-volume
             mountPath: "/var/log"
+      nodeSelector:
+        role: workload
+      tolerations:
+      - key: "workload"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
       volumes:
         - name: secrets-store-inline
           csi:

--- a/src/app/charts/catalogservice/templates/deployment.yaml
+++ b/src/app/charts/catalogservice/templates/deployment.yaml
@@ -59,13 +59,13 @@ spec:
           - name: var-log-volume
             mountPath: "/var/log"
 ### This is an example of how to target a dedicated user node pool.
-#      nodeSelector:
-#        role: workload
-#      tolerations:
-#      - key: "workload"
-#        operator: "Equal"
-#        value: "true"
-#        effect: "NoSchedule"
+      nodeSelector:
+        role: workload
+      tolerations:
+      - key: "workload"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
       volumes:
         - name: secrets-store-inline
           csi:

--- a/src/app/charts/healthservice/templates/deployment.yaml
+++ b/src/app/charts/healthservice/templates/deployment.yaml
@@ -51,6 +51,11 @@ spec:
             mountPath: "/tmp"
           - name: var-log-volume
             mountPath: "/var/log"
+      tolerations:
+      - key: "workload"
+        operator: "Eqal"
+        value: "true"
+        effect: "NoSchedule"
       volumes:
         - name: secrets-store-inline
           csi:

--- a/src/app/charts/healthservice/templates/deployment.yaml
+++ b/src/app/charts/healthservice/templates/deployment.yaml
@@ -51,9 +51,11 @@ spec:
             mountPath: "/tmp"
           - name: var-log-volume
             mountPath: "/var/log"
+      nodeSelector:
+        role: workload
       tolerations:
       - key: "workload"
-        operator: "Eqal"
+        operator: "Equal"
         value: "true"
         effect: "NoSchedule"
       volumes:

--- a/src/config/ingress-nginx/values.helm.yaml
+++ b/src/config/ingress-nginx/values.helm.yaml
@@ -22,7 +22,7 @@ controller:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "10254"
-  tolerations:
+  tolerations: # Schedule the ingress controller on our user node pool
   - key: "workload"
     operator: "Equal"
     value: "true"

--- a/src/config/ingress-nginx/values.helm.yaml
+++ b/src/config/ingress-nginx/values.helm.yaml
@@ -22,6 +22,11 @@ controller:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "10254"
+  tolerations:
+  - key: "workload"
+    operator: "Equal"
+    value: "true"
+    effect: "NoSchedule"
   service:
     type: LoadBalancer
     enableHttp:  true # enable plain http (req. for cert-manager)

--- a/src/infra/README.md
+++ b/src/infra/README.md
@@ -189,15 +189,13 @@ This Azure Mission-Critical reference implementation uses Linux-only clusters as
 - `azure_policy_enabled` is set to `true` to enable the use of [Azure Policies in Azure Kubernetes Service](https://docs.microsoft.com/azure/aks/use-azure-policy). The policy configured in the reference implementation is in "audit-only" mode. It is mostly integrated to demonstrate how to set this up through Terraform.
 - `oms_agent` is configured to enable the Container Insights addon and ship AKS monitoring data to Azure Log Analytics via an in-cluster OMS Agent (DaemonSet).
 - Diagnostic settings are configured to store all log and metric data in Log Analytics.
-- `default_node_pool` settings
+- `default_node_pool` (used as [system node pool](https://docs.microsoft.com/azure/aks/use-system-pools)) settings
   - `availability_zones` is set to `3` to leverage all three AZs in a given region.
-  - `enable_auto_scaling` is configured to let the default node pool automatically scale out if needed.
+  - `enable_auto_scaling` is configured to let all node pools automatically scale out if needed.
   - `os_disk_type` is set to `Ephemeral` to leverage [Ephemeral OS disks](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os) for performance reasons.
   - `upgrade_settings` `max_surge` is set to `33%` which is the [recommended value for production workloads](https://docs.microsoft.com/azure/aks/upgrade-cluster#customize-node-surge-upgrade).
-
-> **Important!** In production environments it's recommended to separate system and user node pools (see [Manage system node pools in Azure Kubernetes Service](https://docs.microsoft.com/azure/aks/use-system-pools)). This Azure Mission-Critical reference implementation is using a single (system) node pool for cost-saving purposes and to reduce overhead.
-
-> The `kubernetes.tf` file contains a commented-out example for an additional user node pool with a taint `workload=true:NoSchedule` set to prevent non-workload pods from being scheduled. The `node_label` set to `role=workload` can be used to target this node pool when deploying a workload (see [charts/catalogservice](/src/app/charts/catalogservice/) for an example).
+- Separate "workload" (aka user) node pool with same settings as "system" node pool but different VM SKUs and auto-scale settings.
+  - The user node pool is configured with a taint `workload=true:NoSchedule` to prevent non-workload pods from being scheduled. The `node_label` set to `role=workload` can be used to target this node pool when deploying a workload (see [charts/catalogservice](/src/app/charts/catalogservice/) for an example).
 
 Individual stamps are considered ephemeral and stateless. Updates to the infrastructure and application are following a [Zero-downtime Update Strategy](/docs/reference-implementation/DeployAndTest-DevOps-Zero-Downtime-Update-Strategy.md) and do not touch existing stamps. Updates to Kubernetes are therefore primarily rolled out by releasing new versions and replacing existing stamps. To update node images between two releases, the `automatic_channel_upgrade` in combination with `maintenance_window` is used:
 

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -71,10 +71,10 @@ resource "azurerm_kubernetes_cluster" "stamp" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "workload" {
-  name                  = "workloadpool" # Name of the workload node pool
+  name                  = "workloadpool"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.stamp.id
   vm_size               = var.aks_user_node_pool_sku_size
-  enable_auto_scaling   = true # Enable autoscaling
+  enable_auto_scaling   = true
   min_count             = var.aks_user_node_pool_autoscale_minimum
   max_count             = var.aks_user_node_pool_autoscale_maximum
   vnet_subnet_id        = azurerm_subnet.kubernetes.id
@@ -82,7 +82,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "workload" {
   orchestrator_version  = var.aks_kubernetes_version
 
   mode  = "User"    # Define this node pool as a "user" aka workload node pool
-  zones = [1, 2, 3] # Distribute user node pool nodes across all availability zones
+  zones = [1, 2, 3]
 
   upgrade_settings {
     max_surge = "33%"

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -71,7 +71,7 @@ resource "azurerm_kubernetes_cluster" "stamp" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "workload" {
-  name                  = "workload1" # Name of the workload node pool
+  name                  = "workloadpool" # Name of the workload node pool
   kubernetes_cluster_id = azurerm_kubernetes_cluster.stamp.id
   vm_size               = var.aks_user_node_pool_sku_size
   enable_auto_scaling   = true # Enable autoscaling

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -74,13 +74,19 @@ resource "azurerm_kubernetes_cluster_node_pool" "workload" {
   name                  = "workload1" # Name of the workload node pool
   kubernetes_cluster_id = azurerm_kubernetes_cluster.stamp.id
   vm_size               = var.aks_user_node_pool_sku_size
-  orchestrator_version  = var.aks_kubernetes_version
   enable_auto_scaling   = true # Enable autoscaling
   min_count             = var.aks_user_node_pool_autoscale_minimum
   max_count             = var.aks_user_node_pool_autoscale_maximum
+  vnet_subnet_id        = azurerm_subnet.kubernetes.id
+  os_disk_type          = "Ephemeral"
+  orchestrator_version  = var.aks_kubernetes_version
 
   mode  = "User"    # Define this node pool as a "user" aka workload node pool
   zones = [1, 2, 3] # Distribute user node pool nodes across all availability zones
+
+  upgrade_settings {
+    max_surge = "33%"
+  }
 
   node_labels = {
     "role" = "workload"

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -20,13 +20,14 @@ resource "azurerm_kubernetes_cluster" "stamp" {
   role_based_access_control_enabled = true
 
   default_node_pool {
-    name                 = "defaultpool"
+    name                 = "systempool"
     vm_size              = var.aks_system_node_pool_sku_size
     enable_auto_scaling  = true
     min_count            = var.aks_system_node_pool_autoscale_minimum
     max_count            = var.aks_system_node_pool_autoscale_maximum
     vnet_subnet_id       = azurerm_subnet.kubernetes.id
     os_disk_type         = "Ephemeral"
+    os_disk_size_gb      = 30
     orchestrator_version = var.aks_kubernetes_version
 
     zones = [1, 2, 3]
@@ -69,31 +70,28 @@ resource "azurerm_kubernetes_cluster" "stamp" {
   tags = var.default_tags
 }
 
-# IMPORTANT - THIS IS JUST AN EXAMPLE FOR A SECONDARY USER NODE POOL.
-# The workload node pool is not used in this reference implementation.
-#
-#resource "azurerm_kubernetes_cluster_node_pool" "workload" {
-#  name                  = "workload1" # Name of the workload node pool
-#  kubernetes_cluster_id = azurerm_kubernetes_cluster.stamp.id
-#  vm_size               = "Standard_DS2_v2" # Adjust SKU size based on workload needs
-#  orchestrator_version  = var.aks_kubernetes_version
-#  enable_auto_scaling   = true # Enable autoscaling
-#  min_count             = 3    # Adjust minimum number of nodes based on workload needs
-#  max_count             = 6    # Adjust maximum number of nodes based on workload needs
-#
-#  mode  = "User"    # Define this node pool as a "user" aka workload node pool
-#  zones = [1, 2, 3] # Distribute user node pool nodes across all availability zones
-#
-#  node_labels = {
-#    "role" = "workload"
-#  }
-#
-#  node_taints = [              # this prevents pods from accidentially being scheduled on the workload node pool
-#    "workload=true:NoSchedule" # each pod / deployments needs a toleration for this taint
-#  ]
-#
-#  tags = var.default_tags
-#}
+resource "azurerm_kubernetes_cluster_node_pool" "workload" {
+  name                  = "workload1" # Name of the workload node pool
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.stamp.id
+  vm_size               = var.aks_user_node_pool_sku_size
+  orchestrator_version  = var.aks_kubernetes_version
+  enable_auto_scaling   = true # Enable autoscaling
+  min_count             = var.aks_user_node_pool_autoscale_minimum
+  max_count             = var.aks_user_node_pool_autoscale_maximum
+
+  mode  = "User"    # Define this node pool as a "user" aka workload node pool
+  zones = [1, 2, 3] # Distribute user node pool nodes across all availability zones
+
+  node_labels = {
+    "role" = "workload"
+  }
+
+  node_taints = [              # this prevents pods from accidentially being scheduled on the workload node pool
+    "workload=true:NoSchedule" # each pod / deployments needs a toleration for this taint
+  ]
+
+  tags = var.default_tags
+}
 
 ####################################### DIAGNOSTIC SETTINGS #######################################
 

--- a/src/infra/workload/releaseunit/modules/stamp/variables.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/variables.tf
@@ -67,17 +67,32 @@ variable "aks_kubernetes_version" {
 }
 
 variable "aks_system_node_pool_sku_size" {
-  description = "VM SKU size used for AKS default (system) node pool nodes"
+  description = "VM SKU of the AKS system nodes"
   type        = string
 }
 
 variable "aks_system_node_pool_autoscale_minimum" {
-  description = "Minimum number of AKS worker nodes (system node pool) for auto-scale settings"
+  description = "Minimum number of AKS system nodes for auto-scale settings"
   type        = number
 }
 
 variable "aks_system_node_pool_autoscale_maximum" {
-  description = "Maximum number of AKS worker nodes (system node pool) for auto-scale settings"
+  description = "Maximum number of AKS system nodes for auto-scale settings"
+  type        = number
+}
+
+variable "aks_user_node_pool_sku_size" {
+  description = "VM SKU of the AKS worker nodes"
+  type        = string
+}
+
+variable "aks_user_node_pool_autoscale_minimum" {
+  description = "Minimum number of AKS worker nodes for auto-scale settings"
+  type        = number
+}
+
+variable "aks_user_node_pool_autoscale_maximum" {
+  description = "Maximum number of AKS worker nodes for auto-scale settings"
   type        = number
 }
 

--- a/src/infra/workload/releaseunit/stamp.tf
+++ b/src/infra/workload/releaseunit/stamp.tf
@@ -43,6 +43,11 @@ module "stamp" {
   aks_system_node_pool_autoscale_minimum = var.aks_system_node_pool_autoscale_minimum
   aks_system_node_pool_autoscale_maximum = var.aks_system_node_pool_autoscale_maximum
 
+  aks_user_node_pool_sku_size          = var.aks_user_node_pool_sku_size
+  aks_user_node_pool_autoscale_minimum = var.aks_user_node_pool_autoscale_minimum
+  aks_user_node_pool_autoscale_maximum = var.aks_user_node_pool_autoscale_maximum
+
+
   event_hub_thoughput_units         = var.event_hub_thoughput_units
   event_hub_enable_auto_inflate     = var.event_hub_enable_auto_inflate
   event_hub_auto_inflate_maximum_tu = var.event_hub_auto_inflate_maximum_tu

--- a/src/infra/workload/releaseunit/variables-e2e.tfvars
+++ b/src/infra/workload/releaseunit/variables-e2e.tfvars
@@ -1,9 +1,11 @@
 # Variable file for E2E env
 vnet_address_space = "10.1.0.0/18" # /18 allows for up to 4 stamps
 
+aks_system_node_pool_sku_size          = "Standard_D2s_v3" # Adjust as needed for your workload
 aks_system_node_pool_autoscale_minimum = 2
 aks_system_node_pool_autoscale_maximum = 3
 
+aks_user_node_pool_sku_size          = "Standard_F8s_v2" # Adjust as needed for your workload
 aks_user_node_pool_autoscale_minimum = 2
 aks_user_node_pool_autoscale_maximum = 3
 

--- a/src/infra/workload/releaseunit/variables-e2e.tfvars
+++ b/src/infra/workload/releaseunit/variables-e2e.tfvars
@@ -1,9 +1,11 @@
 # Variable file for E2E env
 vnet_address_space = "10.1.0.0/18" # /18 allows for up to 4 stamps
 
-aks_system_node_pool_sku_size          = "Standard_F8s_v2" # be aware of the disk size requirement for emphemral disks. Thus we currently cannot use a smaller SKU
-aks_system_node_pool_autoscale_minimum = 2                 # We need at least two nodes to run all the pods of our workload (plus system pods)
+aks_system_node_pool_autoscale_minimum = 2
 aks_system_node_pool_autoscale_maximum = 3
+
+aks_user_node_pool_autoscale_minimum = 2
+aks_user_node_pool_autoscale_maximum = 3
 
 event_hub_thoughput_units     = 1
 event_hub_enable_auto_inflate = false

--- a/src/infra/workload/releaseunit/variables-int.tfvars
+++ b/src/infra/workload/releaseunit/variables-int.tfvars
@@ -1,9 +1,11 @@
 # Variable file for INT env
 vnet_address_space = "10.1.0.0/18" # /18 allows for up to 4 stamps
 
+aks_system_node_pool_sku_size          = "Standard_D2s_v3" # Adjust as needed for your workload
 aks_system_node_pool_autoscale_minimum = 2
 aks_system_node_pool_autoscale_maximum = 6
 
+aks_user_node_pool_sku_size          = "Standard_F8s_v2" # Adjust as needed for your workload
 aks_user_node_pool_autoscale_minimum = 2
 aks_user_node_pool_autoscale_maximum = 6
 

--- a/src/infra/workload/releaseunit/variables-int.tfvars
+++ b/src/infra/workload/releaseunit/variables-int.tfvars
@@ -1,9 +1,11 @@
 # Variable file for INT env
 vnet_address_space = "10.1.0.0/18" # /18 allows for up to 4 stamps
 
-aks_system_node_pool_sku_size          = "Standard_F8s_v2" # be aware of the disk size requirement for emphemral disks. Thus we currently cannot use a smaller SKU
-aks_system_node_pool_autoscale_minimum = 2                 # We need at least two nodes to run all the pods of our workload (plus system pods)
+aks_system_node_pool_autoscale_minimum = 2
 aks_system_node_pool_autoscale_maximum = 6
+
+aks_user_node_pool_autoscale_minimum = 2
+aks_user_node_pool_autoscale_maximum = 6
 
 event_hub_thoughput_units     = 1
 event_hub_enable_auto_inflate = false

--- a/src/infra/workload/releaseunit/variables-prod.tfvars
+++ b/src/infra/workload/releaseunit/variables-prod.tfvars
@@ -1,9 +1,11 @@
 # Variable file for PROD env
 vnet_address_space = "10.1.0.0/16" # /16 allows for up to 16 stamps
 
-aks_system_node_pool_sku_size          = "Standard_F8s_v2" # be aware of the disk size requirement for emphemral disks. Thus we currently cannot use a smaller SKU
 aks_system_node_pool_autoscale_minimum = 3
-aks_system_node_pool_autoscale_maximum = 9
+aks_system_node_pool_autoscale_maximum = 6
+
+aks_user_node_pool_autoscale_minimum = 3
+aks_user_node_pool_autoscale_maximum = 12
 
 event_hub_thoughput_units         = 1
 event_hub_enable_auto_inflate     = true

--- a/src/infra/workload/releaseunit/variables-prod.tfvars
+++ b/src/infra/workload/releaseunit/variables-prod.tfvars
@@ -1,9 +1,11 @@
 # Variable file for PROD env
 vnet_address_space = "10.1.0.0/16" # /16 allows for up to 16 stamps
 
+aks_system_node_pool_sku_size          = "Standard_D2s_v3" # Adjust as needed for your workload
 aks_system_node_pool_autoscale_minimum = 3
 aks_system_node_pool_autoscale_maximum = 6
 
+aks_user_node_pool_sku_size          = "Standard_F8s_v2" # Adjust as needed for your workload
 aks_user_node_pool_autoscale_minimum = 3
 aks_user_node_pool_autoscale_maximum = 12
 

--- a/src/infra/workload/releaseunit/variables.tf
+++ b/src/infra/workload/releaseunit/variables.tf
@@ -102,18 +102,36 @@ variable "aks_kubernetes_version" {
 }
 
 variable "aks_system_node_pool_sku_size" {
-  description = "VM SKU of the AKS worker nodes"
+  description = "VM SKU of the AKS system nodes"
   type        = string
-  default     = "Standard_F8s_v2"
+  default     = "Standard_D2s_v3"
 }
 
 variable "aks_system_node_pool_autoscale_minimum" {
-  description = "Minimum number of AKS worker nodes for auto-scale settings"
+  description = "Minimum number of AKS system nodes for auto-scale settings"
   type        = number
   default     = 3
 }
 
 variable "aks_system_node_pool_autoscale_maximum" {
+  description = "Maximum number of AKS system nodes for auto-scale settings"
+  type        = number
+  default     = 9
+}
+
+variable "aks_user_node_pool_sku_size" {
+  description = "VM SKU of the AKS worker nodes"
+  type        = string
+  default     = "Standard_F8s_v2"
+}
+
+variable "aks_user_node_pool_autoscale_minimum" {
+  description = "Minimum number of AKS worker nodes for auto-scale settings"
+  type        = number
+  default     = 3
+}
+
+variable "aks_user_node_pool_autoscale_maximum" {
   description = "Maximum number of AKS worker nodes for auto-scale settings"
   type        = number
   default     = 9


### PR DESCRIPTION
In line with WAF recommendations, we should split into dedicated system and user node pools for AKS

- Adds a user node pool ("workload") and puts taints for nginx and the workload deployments to run there
- Uses smaller VM SKU for the system node pool. Possible by making the OS disk size smaller

@heoelri 

![image](https://user-images.githubusercontent.com/11445087/177750463-be641049-b9c3-4b3c-b0cd-cbe148dc056c.png)

![image](https://user-images.githubusercontent.com/11445087/177750597-4b386470-8449-4a8a-8708-dd2968165e03.png)
![image](https://user-images.githubusercontent.com/11445087/177750650-f0bfeaa2-12a8-47cb-b516-fdd0bf392352.png)
