### PR TITLE
Azure Dashboard - change time range default to 3 days

### DIFF
--- a/src/infra/monitoring/dashboards/globaldashboard.tpl
+++ b/src/infra/monitoring/dashboards/globaldashboard.tpl
@@ -1833,12 +1833,12 @@
           "MsPortalFx_TimeRange": {
             "model": {
               "format": "utc",
-              "granularity": "auto",
-              "relative": "1h"
+              "granularity": "30m",
+              "relative": "4320m"
             },
             "displayCache": {
               "name": "UTC Time",
-              "value": "Past hour"
+              "value": "Past 3 days"
             },
             "filteredPartIds": [
               "StartboardPart-MonitorChartPart-1b4b7d17-c58b-450f-9198-09da3c59949c",


### PR DESCRIPTION
I realized most of the time when we use the dashboard to show anything at all, its the INT one and there we need to switch to show a couple of days worth of data.
So, just proposing to change the default here.