### PR TITLE
Fix AKS deployment deletion

### DIFF
--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -403,6 +403,13 @@ stages:
                     echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
                     az aks get-credentials --name $aksClusterName --resource-group $aksClusterResourceGroup --overwrite-existing
 
+                    $ingressNamespace = "ingress-nginx"
+
+                    # First delete the ingress controllers
+                    echo "*** Deleting all deployments in namespace $ingressNamespace"
+                    kubectl delete --all deployments --namespace=$ingressNamespace
+
+                    # Now delete all the workload deployments
                     echo "*** Deleting all deployments in namespace $(workloadNamespace)"
                     kubectl delete --all deployments --namespace=$(workloadNamespace)
                   }

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -390,7 +390,7 @@ stages:
                 inlineScript: |
 
                   # Find AKS clusters with the prefix $(oldReleasePrefix)
-                  $aksClusters = az resource list --tag prefix="$(oldReleasePrefix)" --query "[?type == 'Microsoft.ContainerService/managedClusters']" | ConvertFrom-Json
+                  $aksClusters = az aks list --query "[?tags.Prefix=='$(oldReleasePrefix)']" | ConvertFrom-Json
 
                   echo "*** Found $($aksClusters.Count) AKS cluster(s) for prefix $(oldReleasePrefix)"
 


### PR DESCRIPTION
Somehow az aks list seems to be a bit more reliable in catching the clusters. Not sure why, though..

Also added explicit deletion of nginx as part of this.