### PR TITLE
Include the location header when creating new rating

### DIFF
--- a/src/app/AlwaysOn.CatalogService/Controllers/RatingsController.cs
+++ b/src/app/AlwaysOn.CatalogService/Controllers/RatingsController.cs
@@ -141,7 +141,7 @@ namespace AlwaysOn.CatalogService.Controllers
                 return StatusCode((int)HttpStatusCode.InternalServerError, $"Error in processing. Correlation ID: {Activity.Current?.RootId}");
             }
 
-            return StatusCode((int)HttpStatusCode.Accepted);
+            return AcceptedAtRoute(nameof(GetRatingByIdAsync), new { itemId = itemId, ratingId = rating.Id });
         }
 
         /// <summary>


### PR DESCRIPTION
I noticed that the Ratings API doesn't return the Location header when creating a rating. This PR fixes that.