### PR TITLE
NODE_OPTIONS not needed anymore

### DIFF
--- a/src/app/AlwaysOn.UI/Dockerfile
+++ b/src/app/AlwaysOn.UI/Dockerfile
@@ -1,9 +1,6 @@
 # Create build environment
 FROM node:18.7.0 as build-env
 
-# enable node 17 support for vue-cli
-ENV NODE_OPTIONS=--openssl-legacy-provider
-
 WORKDIR /app
 COPY . ./
 RUN npm install && \


### PR DESCRIPTION
With the change to Node 18, the `--openssl-legacy-provider` is not needed anymore.