### PR TITLE
Improve load testing loop to prevent timeouts

### DIFF
--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -217,7 +217,7 @@ stages:
                   throw "*** ERROR: Test result for run $($result.testRunId) is 'FAILED'. Test did not match the defined test criteria."
                 }
 
-              } elseif (($result.status -eq "FAILED") -or ($result.status -eq "CANCELLED")) {
+              } elseif ($result.status -in "FAILED","CANCELLED") {
                 # test ended in failed or cancelled (manually stopped) state
                 throw "*** ERROR: Test run $(testRunId) ended in $($result.status) state."
               } else {

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -200,7 +200,7 @@ stages:
                           -testRunId "$(testRunId)"
               $testRunStatus = ($result).status
 
-              if ($result.status -eq "DONE") {
+              if ($result.status -eq "DONE") { # other states are FAILED, EXECUTING and CANCELLED
                 # test has successfully finished
                 echo "*** Test Run $(testRunId) was successfully completed. Status: $testRunStatus"
 
@@ -217,9 +217,9 @@ stages:
                   throw "*** ERROR: Test result for test run $($result.testRunId) is failed. Test did not match the defined test criteria."
                 }
 
-              } elseif ($result.status -eq "FAILED") {
-                # test ended in failed state
-                throw "*** ERROR: Test run $(testRunId) ended in failed state."
+              } elseif (($result.status -eq "FAILED") -or ($result.status -eq "CANCELLED")) {
+                # test ended in failed or cancelled (manually stopped) state
+                throw "*** ERROR: Test run $(testRunId) ended in $($result.status) state."
               } else {
                 # test is still running
                 echo "*** Test Run $(testRunId) is in status $testRunStatus"

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -199,10 +199,12 @@ stages:
                           -apiEndpoint "$(azureLoadTestDataPlaneURI)" `
                           -testRunId "$(testRunId)"
               $testRunStatus = ($result).status
-              echo "*** Test Run $(testRunId) is in status $testRunStatus"
-              if ($result.status -eq "DONE") {
 
-                echo $result
+              if ($result.status -eq "DONE") {
+                # test has successfully finished
+                echo "*** Test Run $(testRunId) was successfully completed. Status: $testRunStatus"
+
+                # processing test data and publish it in azure devops
                 $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
                 $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
                 New-Item -Path results -ItemType "directory"
@@ -212,9 +214,15 @@ stages:
                 Invoke-WebRequest $logsUrl -OutFile "results/logs.zip"
 
                 if ($result.testResult -eq "FAILED") {
-                  throw "*** ERROR: Test $($result.testRunId) failed."
+                  throw "*** ERROR: Test result for test run $($result.testRunId) is failed. Test did not match the defined test criteria."
                 }
 
+              } else if ($result.status -eq "FAILED") {
+                # test ended in failed state
+                throw "*** ERROR: Test run $(testRunId) ended in failed state."
+              } else {
+                # test is still running
+                echo "*** Test Run $(testRunId) is in status $testRunStatus"
               }
 
               # todo - timeout?

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -217,7 +217,7 @@ stages:
                   throw "*** ERROR: Test result for test run $($result.testRunId) is failed. Test did not match the defined test criteria."
                 }
 
-              } else if ($result.status -eq "FAILED") {
+              } elseif ($result.status -eq "FAILED") {
                 # test ended in failed state
                 throw "*** ERROR: Test run $(testRunId) ended in failed state."
               } else {

--- a/src/infra/README.md
+++ b/src/infra/README.md
@@ -122,6 +122,7 @@ As of May 2022, following regions have been successfully tested with the referen
 - eastasia
 - japaneast
 - koreacentral
+- centralindia
 
 > Note: Depending on which regions you select, you might need to first request quota with Azure Support for some of the services (mostly for AKS VMs and Cosmos DB).
 


### PR DESCRIPTION
Small improvement for the load testing loop (that's waiting for the test to finish) to prevent timeouts. 

This closes issue #535 found by @svgupta97! 