### PR TITLE
Update terraform diag logs to log_category_types

### DIFF
--- a/src/infra/monitoring/grafana/terraform/globalresources/la-wpspace-config.tf
+++ b/src/infra/monitoring/grafana/terraform/globalresources/la-wpspace-config.tf
@@ -7,7 +7,7 @@ resource "azurerm_monitor_diagnostic_setting" "diag_settings_afd" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.frontdoor.logs
+    for_each = data.azurerm_monitor_diagnostic_categories.frontdoor.log_category_types
 
     content {
       category = entry.value
@@ -46,7 +46,7 @@ resource "azurerm_monitor_diagnostic_setting" "acr" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.acr.logs
+    for_each = data.azurerm_monitor_diagnostic_categories.acr.log_category_types
 
     content {
       category = entry.value

--- a/src/infra/monitoring/grafana/terraform/stamps/la-wspace-config.tf
+++ b/src/infra/monitoring/grafana/terraform/stamps/la-wspace-config.tf
@@ -9,7 +9,7 @@ resource "azurerm_monitor_diagnostic_setting" "appservice" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.appservice[each.key].logs
+    for_each = data.azurerm_monitor_diagnostic_categories.appservice[each.key].log_category_types
 
     content {
       category = entry.value
@@ -47,7 +47,7 @@ resource "azurerm_monitor_diagnostic_setting" "pgprimary" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.pgprimary.logs
+    for_each = data.azurerm_monitor_diagnostic_categories.pgprimary.log_category_types
 
     content {
       category = entry.value
@@ -85,7 +85,7 @@ resource "azurerm_monitor_diagnostic_setting" "pgreplica" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.pgreplica[each.key].logs
+    for_each = data.azurerm_monitor_diagnostic_categories.pgreplica[each.key].log_category_types
 
     content {
       category = entry.value
@@ -124,7 +124,7 @@ resource "azurerm_monitor_diagnostic_setting" "vnet" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.vnet[each.key].logs
+    for_each = data.azurerm_monitor_diagnostic_categories.vnet[each.key].log_category_types
 
     content {
       category = entry.value
@@ -163,7 +163,7 @@ resource "azurerm_monitor_diagnostic_setting" "asp" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.asp[each.key].logs
+    for_each = data.azurerm_monitor_diagnostic_categories.asp[each.key].log_category_types
 
     content {
       category = entry.value
@@ -202,7 +202,7 @@ resource "azurerm_monitor_diagnostic_setting" "akv" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.akv[each.key].logs
+    for_each = data.azurerm_monitor_diagnostic_categories.akv[each.key].log_category_types
 
     content {
       category = entry.value

--- a/src/infra/workload/globalresources/acr.tf
+++ b/src/infra/workload/globalresources/acr.tf
@@ -33,7 +33,7 @@ resource "azurerm_monitor_diagnostic_setting" "acr" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.acr.logs
+    for_each = data.azurerm_monitor_diagnostic_categories.acr.log_category_types
 
     content {
       category = entry.value

--- a/src/infra/workload/globalresources/cosmosdb.tf
+++ b/src/infra/workload/globalresources/cosmosdb.tf
@@ -122,7 +122,7 @@ resource "azurerm_monitor_diagnostic_setting" "cosmosdb" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.cosmosdb.logs
+    for_each = data.azurerm_monitor_diagnostic_categories.cosmosdb.log_category_types
 
     content {
       category = entry.value

--- a/src/infra/workload/globalresources/frontdoor.tf
+++ b/src/infra/workload/globalresources/frontdoor.tf
@@ -219,7 +219,7 @@ resource "azurerm_monitor_diagnostic_setting" "frontdoor" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.frontdoor.logs
+    for_each = data.azurerm_monitor_diagnostic_categories.frontdoor.log_category_types
 
     content {
       category = entry.value

--- a/src/infra/workload/globalresources/storage.tf
+++ b/src/infra/workload/globalresources/storage.tf
@@ -41,7 +41,7 @@ resource "azurerm_monitor_diagnostic_setting" "storage_global" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.global_public.logs
+    for_each = data.azurerm_monitor_diagnostic_categories.global_public.log_category_types
 
     content {
       category = entry.value

--- a/src/infra/workload/releaseunit/modules/stamp/eventhub.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/eventhub.tf
@@ -71,7 +71,7 @@ resource "azurerm_monitor_diagnostic_setting" "eventhub" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.eventhub.logs
+    for_each = data.azurerm_monitor_diagnostic_categories.eventhub.log_category_types
 
     content {
       category = entry.value

--- a/src/infra/workload/releaseunit/modules/stamp/keyvault.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/keyvault.tf
@@ -47,7 +47,7 @@ resource "azurerm_monitor_diagnostic_setting" "kv" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.kv.logs
+    for_each = data.azurerm_monitor_diagnostic_categories.kv.log_category_types
 
     content {
       category = entry.value

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -113,7 +113,7 @@ resource "azurerm_monitor_diagnostic_setting" "aks" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.aks.logs
+    for_each = data.azurerm_monitor_diagnostic_categories.aks.log_category_types
 
     content {
       category = entry.value

--- a/src/infra/workload/releaseunit/modules/stamp/network.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/network.tf
@@ -100,7 +100,7 @@ resource "azurerm_monitor_diagnostic_setting" "vnet" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.vnet.logs
+    for_each = data.azurerm_monitor_diagnostic_categories.vnet.log_category_types
 
     content {
       category = entry.value

--- a/src/infra/workload/releaseunit/modules/stamp/storage.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/storage.tf
@@ -78,7 +78,7 @@ resource "azurerm_monitor_diagnostic_setting" "storage_public" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.storage_public.logs
+    for_each = data.azurerm_monitor_diagnostic_categories.storage_public.log_category_types
 
     content {
       category = entry.value
@@ -118,7 +118,7 @@ resource "azurerm_monitor_diagnostic_setting" "storage_public_blob" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.storage_public_blob.logs
+    for_each = data.azurerm_monitor_diagnostic_categories.storage_public_blob.log_category_types
 
     content {
       category = entry.value
@@ -161,7 +161,7 @@ resource "azurerm_monitor_diagnostic_setting" "storage_private" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.storage_private.logs
+    for_each = data.azurerm_monitor_diagnostic_categories.storage_private.log_category_types
 
     content {
       category = entry.value
@@ -201,7 +201,7 @@ resource "azurerm_monitor_diagnostic_setting" "storage_private_blob" {
 
   dynamic "log" {
     iterator = entry
-    for_each = data.azurerm_monitor_diagnostic_categories.storage_private_blob.logs
+    for_each = data.azurerm_monitor_diagnostic_categories.storage_private_blob.log_category_types
 
     content {
       category = entry.value


### PR DESCRIPTION
azurerm_monitor_diagnostic_categories.logs has been deprecated in favor of log_category_types

Validated in e2e