### PR TITLE
Temporary switch to AzAPI for MALT deployment

### DIFF
--- a/src/testing/loadtest-azure/infra/main.tf
+++ b/src/testing/loadtest-azure/infra/main.tf
@@ -26,7 +26,7 @@ resource "azurerm_resource_group" "deployment" {
 }
 
 resource "azapi_resource" "azurerm_load_test" {
-  type      = "Microsoft.LoadTestService/loadTests@2022-06-01-preview"
+  type      = "Microsoft.LoadTestService/loadTests@2022-04-15-preview"
   name      = "${local.prefix}-azloadtest"
   parent_id = azurerm_resource_group.deployment.id
 

--- a/src/testing/loadtest-azure/infra/main.tf
+++ b/src/testing/loadtest-azure/infra/main.tf
@@ -45,6 +45,8 @@ output "azureLoadTestDataPlaneURI" {
   value = azapi_resource.azurerm_load_test.dataPlaneURI
 }
 
+### Currently deployed via AzAPI ### 
+#
 # resource "azurerm_load_test" "deployment" {
 #   name                = "${local.prefix}-azloadtest"
 #   resource_group_name = azurerm_resource_group.deployment.name

--- a/src/testing/loadtest-azure/infra/main.tf
+++ b/src/testing/loadtest-azure/infra/main.tf
@@ -42,7 +42,7 @@ output "azureLoadTestName" {
 }
 
 output "azureLoadTestDataPlaneURI" {
-  value = azapi_resource.azurerm_load_test.dataPlaneURI
+  value = jsondecode(azapi_resource.azurerm_load_test.output).properties.dataPlaneURI
 }
 
 ### Currently deployed via AzAPI ### 

--- a/src/testing/loadtest-azure/infra/main.tf
+++ b/src/testing/loadtest-azure/infra/main.tf
@@ -5,7 +5,8 @@ terraform {
       version = "3.21.1"
     }
     azapi = {
-      source = "azure/azapi"
+      source  = "azure/azapi"
+      version = "0.5.0"
     }
   }
 

--- a/src/testing/loadtest-azure/infra/main.tf
+++ b/src/testing/loadtest-azure/infra/main.tf
@@ -4,6 +4,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "3.21.1"
     }
+    azapi = {
+      source = "azure/azapi"
+    }
   }
 
   backend "azurerm" {}
@@ -21,22 +24,42 @@ resource "azurerm_resource_group" "deployment" {
   tags     = merge(local.default_tags, { "LastDeployedAt" = timestamp() })
 }
 
-resource "azurerm_load_test" "deployment" {
-  name                = "${local.prefix}-azloadtest"
-  resource_group_name = azurerm_resource_group.deployment.name
-  location            = azurerm_resource_group.deployment.location
+resource "azapi_resource" "azurerm_load_test" {
+  type      = "Microsoft.LoadTestService/loadTests@2022-06-01-preview"
+  name      = "${local.prefix}-azloadtest"
+  parent_id = azurerm_resource_group.deployment.id
+
+  location = azurerm_resource_group.deployment.location
 
   tags = local.default_tags
+
+  response_export_values = ["properties.dataPlaneURI"]
 }
 
 output "azureLoadTestName" {
-  value = azurerm_load_test.deployment.name
-}
-
-output "azureLoadResourceGroup" {
-  value = azurerm_load_test.deployment.resource_group_name
+  value = azapi_resource.azurerm_load_test.name
 }
 
 output "azureLoadTestDataPlaneURI" {
-  value = azurerm_load_test.deployment.dataplane_uri
+  value = azapi_resource.azurerm_load_test.dataPlaneURI
+}
+
+# resource "azurerm_load_test" "deployment" {
+#   name                = "${local.prefix}-azloadtest"
+#   resource_group_name = azurerm_resource_group.deployment.name
+#   location            = azurerm_resource_group.deployment.location
+
+#   tags = local.default_tags
+# }
+
+# output "azureLoadTestName" {
+#   value = azurerm_load_test.deployment.name
+# }
+
+# output "azureLoadTestDataPlaneURI" {
+#   value = azurerm_load_test.deployment.dataplane_uri
+# }
+
+output "azureLoadResourceGroup" {
+  value = azurerm_resource_group.deployment.name
 }


### PR DESCRIPTION
Terraform AzureRM is currently using an old API version to deploy the Azure Load Testing service. The used API version will be deprecated soon. See issue #565 for more information.

This PR contains a temporary switch to AzAPI to use the latest API version. The old deployment is commented out.

Deployment is currently tested here: https://dev.azure.com/Mission-Critical/Online/_build/results?buildId=1987&view=results