### PR TITLE
Update AzureRM and Kubernetes and switch to Calico for NP

### DIFF
--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -7,7 +7,7 @@ variables:
 - name: 'terraformVersion'    # Terraform Version
   value: '1.2.9'
 - name: 'kubernetesVersion'   # kubernetes version used for aks clusters
-  value: '1.23.8'
+  value: '1.24.3'
 - name: 'helmVersion'         # helm package manager version
   value: 'v3.9.4'
 - name: 'ingressNginxVersion' # nginx ingress controller helm chart version

--- a/src/infra/monitoring/grafana/terraform/globalresources/main.tf
+++ b/src/infra/monitoring/grafana/terraform/globalresources/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.21.1"
+      version = "3.23.0"
     }
   }
 

--- a/src/infra/monitoring/grafana/terraform/stamps/main.tf
+++ b/src/infra/monitoring/grafana/terraform/stamps/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.21.1"
+      version = "3.23.0"
     }
   }
 

--- a/src/infra/workload/globalresources/main.tf
+++ b/src/infra/workload/globalresources/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.21.1"
+      version = "3.23.0"
     }
   }
 

--- a/src/infra/workload/releaseunit/main.tf
+++ b/src/infra/workload/releaseunit/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.21.1"
+      version = "3.23.0"
     }
   }
 

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -42,7 +42,7 @@ resource "azurerm_kubernetes_cluster" "stamp" {
   network_profile {
     network_plugin = "azure"
     network_mode   = "transparent"
-    network_policy = "azure"
+    network_policy = "calico"
   }
 
   identity {

--- a/src/testing/loadtest-azure/infra/main.tf
+++ b/src/testing/loadtest-azure/infra/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.21.1"
+      version = "3.23.0"
     }
     azapi = {
       source  = "azure/azapi"

--- a/src/testing/loadtest-locust/infra/main.tf
+++ b/src/testing/loadtest-locust/infra/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.21.1"
+      version = "3.23.0"
     }
   }
 

--- a/src/testing/userload-generator/infra/main.tf
+++ b/src/testing/userload-generator/infra/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.21.1"
+      version = "3.23.0"
     }
   }
 


### PR DESCRIPTION
This PR aligns our implementation with our documented recommendations. In our design recommendations we recommend to "prioritize the use of calico" but the implementation was still using azure network policies.

> Prioritize the use of Calico because it provides a richer feature set with broader community adoption and support.

https://learn.microsoft.com/en-us/azure/architecture/framework/mission-critical/mission-critical-networking-connectivity#design-recommendations-6

This is a preparation to enable more suffisticated network policies. This PR also updates the used Terraform AzureRM provider to 3.23.0 and Kubernetes to 1.24.3.

Changes will be ported to connected. 

PR was tested here: https://dev.azure.com/Mission-Critical/Online/_build/results?buildId=2004&view=results

