### PR TITLE
Fix issue in INT

### DIFF
--- a/.ado/pipelines/templates/jobs-deploy-configuration.yaml
+++ b/.ado/pipelines/templates/jobs-deploy-configuration.yaml
@@ -34,7 +34,9 @@ jobs:
           echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
 
           # Load AKS credentials
-          az aks get-credentials --name $aksClusterName --resource-group $aksClusterResourceGroup --overwrite-existing
+          az aks get-credentials --name $aksClusterName `
+                                 --resource-group $aksClusterResourceGroup `
+                                 --overwrite-existing --admin
 
           # Gather Ingress Load Balancer IP from pipeline artifact json
           $aksIngressIp = $stamp.aks_cluster_ingress_ip_address
@@ -80,7 +82,9 @@ jobs:
           echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
 
           # load AKS cluster credentials
-          az aks get-credentials --name $aksClusterName --resource-group $aksClusterResourceGroup --overwrite-existing
+          az aks get-credentials --name $aksClusterName `
+                                 --resource-group $aksClusterResourceGroup `
+                                 --overwrite-existing --admin
 
           # Apply ConfigMap which configures OMS Agent's log and metric collection. Take a look at the reference file to understand what is being collected/excluded
           echo "*** Apply configmap for OMSAgent (Container Insights) on $aksClusterName"
@@ -112,7 +116,9 @@ jobs:
           echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
 
           # load AKS cluster credentials
-          az aks get-credentials --name $aksClusterName --resource-group $aksClusterResourceGroup --overwrite-existing
+          az aks get-credentials --name $aksClusterName `
+                                 --resource-group $aksClusterResourceGroup `
+                                 --overwrite-existing --admin
 
           # Deploy required custom resource definitions needed for cert-manager
           echo "*** Apply cert-manager CRDs on $aksClusterName"
@@ -169,7 +175,9 @@ jobs:
           echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
 
           # load AKS cluster credentials
-          az aks get-credentials --name $aksClusterName --resource-group $aksClusterResourceGroup --overwrite-existing
+          az aks get-credentials --name $aksClusterName `
+                                 --resource-group $aksClusterResourceGroup `
+                                 --overwrite-existing --admin
 
           # Gather Azure KeyVault name from terraform artifact
           $keyVaultName = $stamp.key_vault_name
@@ -222,7 +230,9 @@ jobs:
           echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
 
           # load AKS cluster credentials
-          az aks get-credentials --name $aksClusterName --resource-group $aksClusterResourceGroup --overwrite-existing
+          az aks get-credentials --name $aksClusterName `
+                                 --resource-group $aksClusterResourceGroup `
+                                 --overwrite-existing --admin
 
           $chaosTestingNamespace = "chaos-testing"
 

--- a/.ado/pipelines/templates/jobs-deploy-configuration.yaml
+++ b/.ado/pipelines/templates/jobs-deploy-configuration.yaml
@@ -33,7 +33,8 @@ jobs:
           $aksClusterResourceGroup = $stamp.resource_group_name
           echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
 
-          # Load AKS credentials
+          # Load AKS credentials using --admin to bypass RBAC and interactive logins
+          echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
           az aks get-credentials --name $aksClusterName `
                                  --resource-group $aksClusterResourceGroup `
                                  --overwrite-existing --admin
@@ -81,7 +82,8 @@ jobs:
           $aksClusterResourceGroup = $stamp.resource_group_name
           echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
 
-          # load AKS cluster credentials
+          # Load AKS credentials using --admin to bypass RBAC and interactive logins
+          echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
           az aks get-credentials --name $aksClusterName `
                                  --resource-group $aksClusterResourceGroup `
                                  --overwrite-existing --admin
@@ -115,7 +117,8 @@ jobs:
           $aksClusterResourceGroup = $stamp.resource_group_name
           echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
 
-          # load AKS cluster credentials
+          # Load AKS credentials using --admin to bypass RBAC and interactive logins
+          echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
           az aks get-credentials --name $aksClusterName `
                                  --resource-group $aksClusterResourceGroup `
                                  --overwrite-existing --admin
@@ -174,7 +177,8 @@ jobs:
           $aksClusterResourceGroup = $stamp.resource_group_name
           echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
 
-          # load AKS cluster credentials
+          # Load AKS credentials using --admin to bypass RBAC and interactive logins
+          echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
           az aks get-credentials --name $aksClusterName `
                                  --resource-group $aksClusterResourceGroup `
                                  --overwrite-existing --admin
@@ -229,7 +233,8 @@ jobs:
           $aksClusterResourceGroup = $stamp.resource_group_name
           echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
 
-          # load AKS cluster credentials
+          # Load AKS credentials using --admin to bypass RBAC and interactive logins
+          echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
           az aks get-credentials --name $aksClusterName `
                                  --resource-group $aksClusterResourceGroup `
                                  --overwrite-existing --admin

--- a/.ado/pipelines/templates/jobs-deploy-workload.yaml
+++ b/.ado/pipelines/templates/jobs-deploy-workload.yaml
@@ -38,6 +38,7 @@ jobs: # using jobs so they each run in parallel
             $region = az account list-locations --query "[?name == '$($stamp.location)'].displayName" -o tsv
             echo "*** Using Azure Region display name $region"
 
+            # Load AKS credentials using --admin to bypass RBAC and interactive logins
             echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
             az aks get-credentials --name $aksClusterName `
                                    --resource-group $aksClusterResourceGroup `
@@ -129,7 +130,7 @@ jobs: # using jobs so they each run in parallel
             $region = az account list-locations --query "[?name == '$($stamp.location)'].displayName" -o tsv
             echo "*** Using Azure Region display name $region"
 
-            # load AKS cluster credentials
+            # Load AKS credentials using --admin to bypass RBAC and interactive logins
             echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
             az aks get-credentials --name $aksClusterName `
                                    --resource-group $aksClusterResourceGroup `
@@ -189,7 +190,7 @@ jobs: # using jobs so they each run in parallel
             $region = az account list-locations --query "[?name == '$($stamp.location)'].displayName" -o tsv
             echo "*** Using Azure Region display name $region"
 
-            # Load AKS / K8s cluster credentials via az aks get-credentials (using IAM permissions)
+            # Load AKS credentials using --admin to bypass RBAC and interactive logins
             echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
             az aks get-credentials --name $aksClusterName `
                                    --resource-group $aksClusterResourceGroup `

--- a/.ado/pipelines/templates/jobs-deploy-workload.yaml
+++ b/.ado/pipelines/templates/jobs-deploy-workload.yaml
@@ -39,7 +39,9 @@ jobs: # using jobs so they each run in parallel
             echo "*** Using Azure Region display name $region"
 
             echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
-            az aks get-credentials --name $aksClusterName --resource-group $aksClusterResourceGroup --overwrite-existing
+            az aks get-credentials --name $aksClusterName `
+                                   --resource-group $aksClusterResourceGroup `
+                                   --overwrite-existing --admin
 
             $fullContainerImageName = Get-Content -Path "$(Pipeline.Workspace)/healthservice-containerImageName/healthservice.txt"
             echo "*** Retrieved container image name from artifact - $fullContainerImageName"
@@ -129,7 +131,9 @@ jobs: # using jobs so they each run in parallel
 
             # load AKS cluster credentials
             echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
-            az aks get-credentials --name $aksClusterName --resource-group $aksClusterResourceGroup --overwrite-existing
+            az aks get-credentials --name $aksClusterName `
+                                   --resource-group $aksClusterResourceGroup `
+                                   --overwrite-existing --admin
 
             $fqdn = $stamp.aks_cluster_ingress_fqdn
             echo "*** Retrieved Ingress Controller FQDN $fqdn for AKS cluster $aksClusterName"
@@ -187,7 +191,9 @@ jobs: # using jobs so they each run in parallel
 
             # Load AKS / K8s cluster credentials via az aks get-credentials (using IAM permissions)
             echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
-            az aks get-credentials --name $aksClusterName --resource-group $aksClusterResourceGroup --overwrite-existing
+            az aks get-credentials --name $aksClusterName `
+                                   --resource-group $aksClusterResourceGroup `
+                                   --overwrite-existing --admin
 
             $fullContainerImageName = Get-Content -Path "$(Pipeline.Workspace)/backgroundprocessor-containerImageName/backgroundprocessor.txt"
             echo "*** Retrieved full container image name from artifact - $fullContainerImageName"

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -384,7 +384,7 @@ stages:
               displayName: 'Delete application deployments on AKS prior to destroy'
               retryCountOnTaskFailure: 1
               inputs:
-                azureSubscription: $(azureServiceConnection)
+                azureSubscription: '$(azureServiceConnection)'
                 scriptType: pscore
                 scriptLocation: inlineScript
                 inlineScript: |
@@ -401,7 +401,9 @@ stages:
                     $aksClusterResourceGroup = $cluster.resourceGroup
 
                     echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
-                    az aks get-credentials --name $aksClusterName --resource-group $aksClusterResourceGroup --overwrite-existing
+                    az aks get-credentials --name $aksClusterName `
+                                           --resource-group $aksClusterResourceGroup `
+                                           --overwrite-existing --admin
 
                     # First delete the ingress controllers
                     echo "*** Deleting all deployments in namespace $(ingressNamespace)"

--- a/.ado/pipelines/templates/stages-full-release.yaml
+++ b/.ado/pipelines/templates/stages-full-release.yaml
@@ -400,6 +400,7 @@ stages:
                     $aksClusterName = $cluster.name
                     $aksClusterResourceGroup = $cluster.resourceGroup
 
+                    # Load AKS credentials using --admin to bypass RBAC and interactive logins
                     echo "*** Load credentials for AKS Cluster $aksClusterName in $aksClusterResourceGroup"
                     az aks get-credentials --name $aksClusterName `
                                            --resource-group $aksClusterResourceGroup `


### PR DESCRIPTION
There's a new issue occuring in INT since the beginning of this week. The issue occurs when deleting the application deployments as part of the destroy process of the cluster.

```console
*** Found 2 AKS cluster(s) for prefix afint06a2
*** Load credentials for AKS Cluster afint06a2-brazilsou-aks in afint06a2-stamp-brazilsouth-rg
WARNING: Merged "afint06a2-brazilsou-aks" as current context in /home/vsts/.kube/config
*** Deleting all deployments in namespace ingress-nginx
To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code DJ4ZUC5HS to authenticate.
Error: failed to get token: waiting for device code authentication to complete: autorest/adal/devicetoken: Error while retrieving OAuth token: Code Expired
```

This indicates that AKS requests an interactive login (aad-integrated cluster). Question for me is why this was working before and since when do we've our clusters AAD-integrated? @sebader thoughts?

This PR uses `--admin` to override K8s RBAC and uses Azure IAM permissions instead.