### PR TITLE
GitHub Action workflow to reset component-updates branch

### DIFF
--- a/.github/workflows/resetBranch.yml
+++ b/.github/workflows/resetBranch.yml
@@ -1,0 +1,24 @@
+name: Reset component-updates branch
+
+on:
+  workflow_dispatch:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  resetBranch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout component-updates
+        run: |
+          git checkout -b component-updates
+
+      - name: Reset branch
+        run: |
+          git reset --hard origin/main
+      
+      - name: Push
+        run: |
+          git push --force


### PR DESCRIPTION
We're running into issues from time to time with inconsistencies between the component-updates and the main branch.

This PR introduces a new GitHub Action workflow to manually trigger a reset of the component-updates branch.