### PR TITLE
Bump Azure Load Test data plane API to `2022-06-01-preview`

### DIFF
--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -43,6 +43,8 @@ variables:
   value: 'alwayson/healthservice'
 
 # Microsoft Azure Load Test (MALT) configuration
+- name: 'azureLoadTestApiVersion' # data plane
+  value: '2022-06-01-preview'
 - name: 'azureLoadTestEngineInstances'
   value: 2
 - name: 'azureLoadTestVUsers'

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -268,7 +268,7 @@ stages:
 
             if ( ($resultUrl) -and ($logsUrl) ) {
               New-Item -Path results -ItemType "directory" -Force
-              echo "*** Download results file from $resultsUrl"
+              echo "*** Download results file from $resultUrl"
               Invoke-WebRequest $resultUrl -OutFile "results/results.zip"
               echo "*** Download logs from $logsUrl"
               Invoke-WebRequest $logsUrl -OutFile "results/logs.zip"

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -241,7 +241,7 @@ stages:
                   echo "*** Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty. Retry $i/3"
                   Start-Sleep -seconds 15
                 } else {
-                  echo "*** Received logsUrl ($logsUrl)
+                  echo "*** Received logsUrl ($logsUrl)"
                   echo "*** Received resultUrl ($resultUrl)"
                 }
 

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -212,13 +212,21 @@ stages:
 
                 # processing test data and publish it in azure devops
                 $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
-                $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
-                New-Item -Path results -ItemType "directory"
-                echo "*** Download resultsUrl"
-                Invoke-WebRequest $resultUrl -OutFile "results/results.zip"
-                echo "*** Download logsUrl"
-                Invoke-WebRequest $logsUrl -OutFile "results/logs.zip"
 
+                $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
+
+                # download results and logs
+                if ( ($resultUrl) -and ($logsUrl) ) {
+                  New-Item -Path results -ItemType "directory"
+                  echo "*** Download resultsUrl"
+                  Invoke-WebRequest $resultUrl -OutFile "results/results.zip"
+                  echo "*** Download logsUrl"
+                  Invoke-WebRequest $logsUrl -OutFile "results/logs.zip"
+                } else {
+                  throw "*** ERROR: Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty."
+                }
+
+                # throw an error when testResult is FAILED
                 if ($result.testResult -eq "FAILED") {
                   throw "*** ERROR: Test result for run $($result.testRunId) is 'FAILED'. Test did not match the defined test criteria."
                 }

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -248,8 +248,8 @@ stages:
           script: |
             wget https://raw.githubusercontent.com/Azure-Samples/jmeter-aci-terraform/main/scripts/jtl_junit_converter.py -O $(System.DefaultWorkingDirectory)/junit-converter.py
             unzip results/results.zip -d results
-            JMETER_RESULTS=results/testreport.csv
-            JUNIT_RESULTS=output.xml
+            $JMETER_RESULTS=results/testreport.csv
+            $JUNIT_RESULTS=output.xml
             python3 junit-converter.py $JMETER_RESULTS $JUNIT_RESULTS
         
       - task: PublishTestResults@2

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -240,21 +240,25 @@ stages:
               throw "*** ERROR: Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty."
             }
 
-
-      - script: |
-          wget https://raw.githubusercontent.com/Azure-Samples/jmeter-aci-terraform/main/scripts/jtl_junit_converter.py -O $(System.DefaultWorkingDirectory)/junit-onverter.py
-          unzip results/results.zip -d results
-          JMETER_RESULTS=results/testreport.csv
-          JUNIT_RESULTS=output.xml
-          python3 junit-onverter.py $JMETER_RESULTS $JUNIT_RESULTS
+      - task: PowerShell@2
         displayName: 'RESULTS: Convert JMeter Results to JUnit Format'
-
+        condition: succeeded()
+        inputs:
+          targetType: inline
+          script: |
+            wget https://raw.githubusercontent.com/Azure-Samples/jmeter-aci-terraform/main/scripts/jtl_junit_converter.py -O $(System.DefaultWorkingDirectory)/junit-converter.py
+            unzip results/results.zip -d results
+            JMETER_RESULTS=results/testreport.csv
+            JUNIT_RESULTS=output.xml
+            python3 junit-converter.py $JMETER_RESULTS $JUNIT_RESULTS
+        
       - task: PublishTestResults@2
+        displayName: 'RESULTS: Publish Load Testing Results'
+        condition: succeeded()
         inputs:
           testResultsFormat: 'JUnit'
           testResultsFiles: 'output.xml'
           failTaskOnFailedTests: false
-        displayName: 'RESULTS: Publish Load Testing Results'
 
       # publish load test results as pipeline artifacts in azure devops
       - task: PublishBuildArtifacts@1

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -214,40 +214,57 @@ stages:
                 echo "*** Test Run $(testRunId) is in status $testRunStatus"
               }
 
-            $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
-            $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
+              $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
+              $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
 
               # todo - timeout?
             } while ($result.status -ne "DONE")
 
             echo "*** Test Run $(testRunId) was completed. Test Run Status: $testRunStatus Test Status: $($result.testResult)"
             echo "*** Portal URL: $($result.portalUrl)"
-            
+
+            # throw an error when testResult is FAILED
+            if ($result.testResult -eq "FAILED") {
+              throw "*** ERROR: Test result for run $($result.testRunId) is 'FAILED'. Test did not match the defined test criteria."
+            }
+
+      - task: AzureCLI@2
+        displayName: 'RESULTS: Download and convert JMeter results'
+        condition: succeeded()
+        inputs:
+          azureSubscription: $(azureServiceConnection)
+          scriptType: pscore
+          scriptLocation: inlineScript
+          inlineScript: |
+
             # processing test data and publish it in azure devops
             # download results and logs - retry if empty
-            if ( (!$resultUrl) -or (!$logsUrl) ) {
-            echo "*** Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty. Retrying.."
-            
-              $i = 0
-              do {
-                $outputArtifacts = ($(System.DefaultWorkingDirectory)/src/testing/loadtest-azure/scripts/loadtest-get-run.ps1 `
-                  -apiEndpoint "$(azureLoadTestDataPlaneURI)" `
-                  -apiVersion "$(azureLoadTestApiVersion)" `
-                  -testRunId "$(testRunId)").testArtifacts.outputArtifacts
-                $resultUrl = ($outputArtifacts).resultUrl.url
-                $logsUrl = ($outputArtifacts).logsUrl.url
+            $i = 0
+            do {
+              $result = $(System.DefaultWorkingDirectory)/src/testing/loadtest-azure/scripts/loadtest-get-run.ps1 `
+                -apiEndpoint "$(azureLoadTestDataPlaneURI)" `
+                -apiVersion "$(azureLoadTestApiVersion)" `
+                -testRunId "$(testRunId)")
 
-                if ( (!$resultUrl) -or (!$logsUrl) ) {
-                  echo "*** Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty. Retry $i/3"
-                  Start-Sleep -seconds 15
-                } else {
-                  echo "*** Received logsUrl ($logsUrl)"
-                  echo "*** Received resultUrl ($resultUrl)"
-                }
+              $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
+              $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
 
-                $i++
-              } while ( $i -le 3 )
-            }
+              if (!$resultUrl) {
+                echo "*** resultUrl ($resultUrl) is empty. Retry $i/3"
+                Start-Sleep -seconds 15
+              } else {
+                echo "*** Received resultUrl ($resultUrl)"
+              }
+
+              if (!$logsUrl) {
+                echo "*** logsUrl ($logsUrl) is empty. Retry $i/3"
+                Start-Sleep -seconds 15
+              } else {
+                echo "*** Received logsUrl ($logsUrl)"
+              }
+
+              $i++
+            } while ( $i -le 3 )
 
             if ( ($resultUrl) -and ($logsUrl) ) {
               New-Item -Path results -ItemType "directory"
@@ -259,17 +276,6 @@ stages:
               throw "*** ERROR: Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty."
             }
 
-            # throw an error when testResult is FAILED
-            if ($result.testResult -eq "FAILED") {
-              throw "*** ERROR: Test result for run $($result.testRunId) is 'FAILED'. Test did not match the defined test criteria."
-            }
-
-      - task: PowerShell@2
-        displayName: 'RESULTS: Convert JMeter Results to JUnit Format'
-        condition: succeeded()
-        inputs:
-          targetType: inline
-          script: |
             wget https://raw.githubusercontent.com/Azure-Samples/jmeter-aci-terraform/main/scripts/jtl_junit_converter.py -O $(System.DefaultWorkingDirectory)/junit-converter.py
 
             if (Test-Path results/results.zip) {

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -247,10 +247,16 @@ stages:
           targetType: inline
           script: |
             wget https://raw.githubusercontent.com/Azure-Samples/jmeter-aci-terraform/main/scripts/jtl_junit_converter.py -O $(System.DefaultWorkingDirectory)/junit-converter.py
-            unzip results/results.zip -d results
-            $JMETER_RESULTS=results/testreport.csv
-            $JUNIT_RESULTS=output.xml
-            python3 junit-converter.py $JMETER_RESULTS $JUNIT_RESULTS
+
+            if (Test-Path results/results.zip) {
+              Expand-Archive -Path results/results.zip -DestinationPath results
+              $JMETER_RESULTS=results/testreport.csv
+              $JUNIT_RESULTS=output.xml
+              python3 junit-converter.py $JMETER_RESULTS $JUNIT_RESULTS
+            } else {
+              echo "Skipping conversion. results.zip was not found."
+            }
+            
         
       - task: PublishTestResults@2
         displayName: 'RESULTS: Publish Load Testing Results'

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -219,6 +219,7 @@ stages:
             } while ($result.status -ne "DONE")
 
             echo "*** Test Run $(testRunId) was completed. Status: $testRunStatus"
+            echo "*** Portal URL: $($result.portalUrl)"
 
             # throw an error when testResult is FAILED
             if ($result.testResult -eq "FAILED") {
@@ -229,7 +230,13 @@ stages:
             $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
             $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
 
-            # download results and logs
+            # download results and logs - retry if empty
+            do {
+              echo "*** Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty. Retry $i/3"
+              Start-Sleep -seconds 15
+              $i++
+            } while ( (!$resultUrl) -or (!$logsUrl) -or ($i -le 3) )
+
             if ( ($resultUrl) -and ($logsUrl) ) {
               New-Item -Path results -ItemType "directory"
               echo "*** Download resultsUrl"
@@ -254,7 +261,7 @@ stages:
               $JUNIT_RESULTS=output.xml
               python3 junit-converter.py $JMETER_RESULTS $JUNIT_RESULTS
             } else {
-              echo "Skipping conversion. results.zip was not found."
+              echo "Skipping result data conversion. results.zip was not found."
             }
             
         
@@ -268,6 +275,7 @@ stages:
 
       # publish load test results as pipeline artifacts in azure devops
       - task: PublishBuildArtifacts@1
+        condition: succeeded() 
         inputs:
           artifactName: 'loadtest'
           pathToPublish: '$(System.DefaultWorkingDirectory)/results'

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -220,16 +220,21 @@ stages:
 
             echo "*** Test Run $(testRunId) was completed. Status: $testRunStatus"
             echo "*** Portal URL: $($result.portalUrl)"
-
+            
             # processing test data and publish it in azure devops
-            $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
-            $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
-
             # download results and logs - retry if empty
             $i = 0
             do {
-              echo "*** Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty. Retry $i/3"
-              Start-Sleep -seconds 15
+              $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
+              $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
+
+              if ( (!$resultUrl) -or (!$logsUrl) ) {
+                echo "*** Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty. Retry $i/3"
+                Start-Sleep -seconds 15
+              } else {
+                $i=3
+              }
+
               $i++
             } while ( $i -le 3 )
 

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -226,11 +226,12 @@ stages:
             $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
 
             # download results and logs - retry if empty
+            $i = 0
             do {
               echo "*** Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty. Retry $i/3"
               Start-Sleep -seconds 15
               $i++
-            } while ( (!$resultUrl) -or (!$logsUrl) -or ($i -le 3) )
+            } while ( $i -le 3 )
 
             if ( ($resultUrl) -and ($logsUrl) ) {
               New-Item -Path results -ItemType "directory"

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -244,7 +244,7 @@ stages:
               $result = $(System.DefaultWorkingDirectory)/src/testing/loadtest-azure/scripts/loadtest-get-run.ps1 `
                 -apiEndpoint "$(azureLoadTestDataPlaneURI)" `
                 -apiVersion "$(azureLoadTestApiVersion)" `
-                -testRunId "$(testRunId)")
+                -testRunId "$(testRunId)"
 
               $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
               $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
@@ -264,10 +264,10 @@ stages:
               }
 
               $i++
-            } while ( $i -le 3 )
+            } while ( ($i -le 3) -and (($logsUrl) -and ($resultUrl)) )
 
             if ( ($resultUrl) -and ($logsUrl) ) {
-              New-Item -Path results -ItemType "directory"
+              New-Item -Path results -ItemType "directory" -Force
               echo "*** Download results file from $resultsUrl"
               Invoke-WebRequest $resultUrl -OutFile "results/results.zip"
               echo "*** Download logs from $logsUrl"
@@ -276,13 +276,17 @@ stages:
               throw "*** ERROR: Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty."
             }
 
-            wget https://raw.githubusercontent.com/Azure-Samples/jmeter-aci-terraform/main/scripts/jtl_junit_converter.py -O $(System.DefaultWorkingDirectory)/junit-converter.py
+            #wget https://raw.githubusercontent.com/Azure-Samples/jmeter-aci-terraform/main/scripts/jtl_junit_converter.py -O $(System.DefaultWorkingDirectory)/junit-converter.py
 
             if (Test-Path results/results.zip) {
               Expand-Archive -Path results/results.zip -DestinationPath results
-              $JMETER_RESULTS="results/testreport.csv"
-              $JUNIT_RESULTS="output.xml"
-              python3 junit-converter.py $JMETER_RESULTS $JUNIT_RESULTS
+
+              # merge multiple csv files
+              # Get-ChildItem -Filter results/*.csv | Import-Csv | Export-Csv results/testreport.csv -NoTypeInformation -Append
+
+              #$JMETER_RESULTS="results/testreport.csv"
+              #$JUNIT_RESULTS="output.xml"
+              #python3 junit-converter.py $JMETER_RESULTS $JUNIT_RESULTS
             } else {
               echo "Skipping result data conversion. results.zip was not found."
             }
@@ -291,6 +295,7 @@ stages:
       - task: PublishTestResults@2
         displayName: 'RESULTS: Publish Load Testing Results'
         condition: succeeded()
+        enabled: false
         inputs:
           testResultsFormat: 'JUnit'
           testResultsFiles: 'output.xml'

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -215,18 +215,20 @@ stages:
               }
 
               # download results and logs - retry if empty
-              $i = 0
-              do {
-                $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
-                $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
+              if ($result.status -eq "DONE") {
+                $i = 0
+                do {
+                  $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
+                  $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
 
-                if ( (!$resultUrl) -or (!$logsUrl) ) {
-                  echo "*** Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty. Retry $i/3"
-                  Start-Sleep -seconds 15
-                } 
+                  if ( (!$resultUrl) -or (!$logsUrl) ) {
+                    echo "*** Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty. Retry $i/3"
+                    Start-Sleep -seconds 15
+                  } 
 
-                $i++
-              } while ( (!$resultUrl) -or (!$logsUrl) -or ($i -le 3) )
+                  $i++
+                } while ( ((!$resultUrl) -or (!$logsUrl)) -or ($i -le 3) )
+              }
 
               # todo - timeout?
             } while ($result.status -ne "DONE")

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -221,11 +221,6 @@ stages:
             echo "*** Test Run $(testRunId) was completed. Status: $testRunStatus"
             echo "*** Portal URL: $($result.portalUrl)"
 
-            # throw an error when testResult is FAILED
-            if ($result.testResult -eq "FAILED") {
-              throw "*** ERROR: Test result for run $($result.testRunId) is 'FAILED'. Test did not match the defined test criteria."
-            }
-
             # processing test data and publish it in azure devops
             $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
             $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
@@ -245,6 +240,11 @@ stages:
               Invoke-WebRequest $logsUrl -OutFile "results/logs.zip"
             } else {
               throw "*** ERROR: Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty."
+            }
+
+            # throw an error when testResult is FAILED
+            if ($result.testResult -eq "FAILED") {
+              throw "*** ERROR: Test result for run $($result.testRunId) is 'FAILED'. Test did not match the defined test criteria."
             }
 
       - task: PowerShell@2

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -212,19 +212,77 @@ stages:
               } else {
                 # test is still running
                 echo "*** Test Run $(testRunId) is in status $testRunStatus"
-                $result
               }
+
+              # download results and logs - retry if empty
+              $i = 0
+              do {
+                $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
+                $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
+
+                if ( (!$resultUrl) -or (!$logsUrl) ) {
+                  echo "*** Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty. Retry $i/3"
+                  Start-Sleep -seconds 15
+                } 
+
+                $i++
+              } while ( ((!$resultUrl) -or (!$logsUrl) -or ($i -le 3) )
 
               # todo - timeout?
             } while ($result.status -ne "DONE")
 
             echo "*** Test Run $(testRunId) was completed. Status: $testRunStatus"
             echo "*** Portal URL: $($result.portalUrl)"
+            
+            # processing test data and publish it in azure devops
+
+            if ( ($resultUrl) -and ($logsUrl) ) {
+              New-Item -Path results -ItemType "directory"
+              echo "*** Download resultsUrl"
+              Invoke-WebRequest $resultUrl -OutFile "results/results.zip"
+              echo "*** Download logsUrl"
+              Invoke-WebRequest $logsUrl -OutFile "results/logs.zip"
+            } else {
+              throw "*** ERROR: Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty."
+            }
 
             # throw an error when testResult is FAILED
             if ($result.testResult -eq "FAILED") {
               throw "*** ERROR: Test result for run $($result.testRunId) is 'FAILED'. Test did not match the defined test criteria."
             }
+
+      - task: PowerShell@2
+        displayName: 'RESULTS: Convert JMeter Results to JUnit Format'
+        condition: succeeded()
+        inputs:
+          targetType: inline
+          script: |
+            wget https://raw.githubusercontent.com/Azure-Samples/jmeter-aci-terraform/main/scripts/jtl_junit_converter.py -O $(System.DefaultWorkingDirectory)/junit-converter.py
+
+            if (Test-Path results/results.zip) {
+              Expand-Archive -Path results/results.zip -DestinationPath results
+              $JMETER_RESULTS=results/testreport.csv
+              $JUNIT_RESULTS=output.xml
+              python3 junit-converter.py $JMETER_RESULTS $JUNIT_RESULTS
+            } else {
+              echo "Skipping result data conversion. results.zip was not found."
+            }
+            
+        
+      - task: PublishTestResults@2
+        displayName: 'RESULTS: Publish Load Testing Results'
+        condition: succeeded()
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: 'output.xml'
+          failTaskOnFailedTests: false
+
+      # publish load test results as pipeline artifacts in azure devops
+      - task: PublishBuildArtifacts@1
+        condition: succeeded() 
+        inputs:
+          artifactName: 'loadtest'
+          pathToPublish: '$(System.DefaultWorkingDirectory)/results'
 
     # All of the next tasks are only applicable in headless mode
     - ${{ if eq(parameters.destroyInfra, 'true') }}:

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -214,21 +214,8 @@ stages:
                 echo "*** Test Run $(testRunId) is in status $testRunStatus"
               }
 
-              # download results and logs - retry if empty
-              if ($result.status -eq "DONE") {
-                $i = 0
-                do {
-                  $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
-                  $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
-
-                  if ( (!$resultUrl) -or (!$logsUrl) ) {
-                    echo "*** Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty. Retry $i/3"
-                    Start-Sleep -seconds 15
-                  } 
-
-                  $i++
-                } while ( ((!$resultUrl) -or (!$logsUrl)) -or ($i -le 3) )
-              }
+            $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
+            $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
 
               # todo - timeout?
             } while ($result.status -ne "DONE")
@@ -237,6 +224,26 @@ stages:
             echo "*** Portal URL: $($result.portalUrl)"
             
             # processing test data and publish it in azure devops
+            # download results and logs - retry if empty
+            if ( (!$resultUrl) -or (!$logsUrl) ) {
+            
+              $i = 0
+              do {
+                $result = $(System.DefaultWorkingDirectory)/src/testing/loadtest-azure/scripts/loadtest-get-run.ps1 `
+                  -apiEndpoint "$(azureLoadTestDataPlaneURI)" `
+                  -apiVersion "$(azureLoadTestApiVersion)" `
+                  -testRunId "$(testRunId)"
+                $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
+                $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
+
+                if ( (!$resultUrl) -or (!$logsUrl) ) {
+                  echo "*** Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty. Retry $i/3"
+                  Start-Sleep -seconds 15
+                } 
+
+                $i++
+              } while ( ((!$resultUrl) -or (!$logsUrl)) -and ($i -le 3) )
+            }
 
             if ( ($resultUrl) -and ($logsUrl) ) {
               New-Item -Path results -ItemType "directory"

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -249,18 +249,12 @@ stages:
               $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
               $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
 
-              if (!$resultUrl) {
-                echo "*** resultUrl ($resultUrl) is empty. Retry $i/3"
+              if ( (!$resultUrl) -and (!$logsUrl) ) {
+                echo "*** Either resultUrl ($resultUrl) or logsUrl ($logsUrl) is empty. Retry $i/3"
                 Start-Sleep -seconds 15
               } else {
-                echo "*** Received resultUrl ($resultUrl)"
-              }
-
-              if (!$logsUrl) {
-                echo "*** logsUrl ($logsUrl) is empty. Retry $i/3"
-                Start-Sleep -seconds 15
-              } else {
-                echo "*** Received logsUrl ($logsUrl)"
+                echo "*** Received resultUrl ($resultUrl) and logsUrl ($logsUrl)"
+                $i=3 # set to 3 to end the loop
               }
 
               $i++

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -113,6 +113,7 @@ stages:
         scriptPath: '$(System.DefaultWorkingDirectory)/src/testing/loadtest-azure/scripts/loadtest-create.ps1'
         arguments:
           -apiEndpoint "$(azureLoadTestDataPlaneURI)" `
+          -apiVersion "$(azureLoadTestApiVersion)" `
           -loadTestDisplayName "$(get-date -f "yyyy-MM-dd hh:ss") load test for build $(Build.BuildId)" `
           -loadTestDescription "Pipeline-embedded load test for $(Build.BuildId) ($(get-date -f "dd/MM/yyyy hh:ss"))" `
           -loadTestTargetUrl "$(azureLoadTestTargetFQDN)" `
@@ -145,6 +146,7 @@ stages:
               ./src/testing/loadtest-azure/scripts/appcomponents-add-to-loadtest.ps1 `
                 -loadTestId "$(loadTestId)" `
                 -apiEndpoint "$(azureLoadTestDataPlaneURI)" `
+                -apiVersion "$(azureLoadTestApiVersion)" `
                 -resourceId "$($stamp.aks_cluster_id)"
 
               echo "*** Adding $($stamp.aks_cluster_id)"
@@ -162,6 +164,7 @@ stages:
           arguments:
             -loadTestId "$(loadTestId)" `
             -apiEndpoint "$(azureLoadTestDataPlaneURI)" `
+            -apiVersion "$(azureLoadTestApiVersion)" `
             -testFileName "$(System.DefaultWorkingDirectory)/src/testing/loadtest-azure/scripts/catalog-test.jmx" `
             -verbose:$true `
             -wait:$true
@@ -177,6 +180,7 @@ stages:
           arguments:
             -loadTestId "$(loadTestId)" `
             -apiEndpoint "$(azureLoadTestDataPlaneURI)" `
+            -apiVersion "$(azureLoadTestApiVersion)" `
             -testRunName "$(get-date -f "yyyy-MM-dd hh:ss") Load Test run triggered by ADO" `
             -testRunDescription "Pipeline executed load test run" `
             -testRunVUsers "$(azureLoadTestVUsers)" `
@@ -198,6 +202,7 @@ stages:
               start-sleep -seconds 90
               $result = $(System.DefaultWorkingDirectory)/src/testing/loadtest-azure/scripts/loadtest-get-run.ps1 `
                           -apiEndpoint "$(azureLoadTestDataPlaneURI)" `
+                          -apiVersion "$(azureLoadTestApiVersion)" `
                           -testRunId "$(testRunId)"
               $testRunStatus = ($result).status
 

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -206,43 +206,40 @@ stages:
                           -testRunId "$(testRunId)"
               $testRunStatus = ($result).status
 
-              $result
-
-              if ($result.status -eq "DONE") { # other states are FAILED, EXECUTING and CANCELLED
-                # test has successfully finished
-                echo "*** Test Run $(testRunId) was successfully completed. Status: $testRunStatus"
-
-                # processing test data and publish it in azure devops
-                $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
-
-                $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
-
-                # download results and logs
-                if ( ($resultUrl) -and ($logsUrl) ) {
-                  New-Item -Path results -ItemType "directory"
-                  echo "*** Download resultsUrl"
-                  Invoke-WebRequest $resultUrl -OutFile "results/results.zip"
-                  echo "*** Download logsUrl"
-                  Invoke-WebRequest $logsUrl -OutFile "results/logs.zip"
-                } else {
-                  throw "*** ERROR: Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty."
-                }
-
-                # throw an error when testResult is FAILED
-                if ($result.testResult -eq "FAILED") {
-                  throw "*** ERROR: Test result for run $($result.testRunId) is 'FAILED'. Test did not match the defined test criteria."
-                }
-
-              } elseif ($result.status -in "FAILED","CANCELLED") {
+              if ($result.status -in "FAILED","CANCELLED") {
                 # test ended in failed or cancelled (manually stopped) state
                 throw "*** ERROR: Test run $(testRunId) ended in $($result.status) state."
               } else {
                 # test is still running
                 echo "*** Test Run $(testRunId) is in status $testRunStatus"
+                $result
               }
 
               # todo - timeout?
             } while ($result.status -ne "DONE")
+
+            echo "*** Test Run $(testRunId) was completed. Status: $testRunStatus"
+
+            # throw an error when testResult is FAILED
+            if ($result.testResult -eq "FAILED") {
+              throw "*** ERROR: Test result for run $($result.testRunId) is 'FAILED'. Test did not match the defined test criteria."
+            }
+
+            # processing test data and publish it in azure devops
+            $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
+            $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
+
+            # download results and logs
+            if ( ($resultUrl) -and ($logsUrl) ) {
+              New-Item -Path results -ItemType "directory"
+              echo "*** Download resultsUrl"
+              Invoke-WebRequest $resultUrl -OutFile "results/results.zip"
+              echo "*** Download logsUrl"
+              Invoke-WebRequest $logsUrl -OutFile "results/logs.zip"
+            } else {
+              throw "*** ERROR: Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty."
+            }
+
 
       - script: |
           wget https://raw.githubusercontent.com/Azure-Samples/jmeter-aci-terraform/main/scripts/jtl_junit_converter.py -O $(System.DefaultWorkingDirectory)/junit-onverter.py

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -240,9 +240,9 @@ stages:
 
             if ( ($resultUrl) -and ($logsUrl) ) {
               New-Item -Path results -ItemType "directory"
-              echo "*** Download resultsUrl"
+              echo "*** Download results file from $resultsUrl"
               Invoke-WebRequest $resultUrl -OutFile "results/results.zip"
-              echo "*** Download logsUrl"
+              echo "*** Download logs from $logsUrl"
               Invoke-WebRequest $logsUrl -OutFile "results/logs.zip"
             } else {
               throw "*** ERROR: Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty."

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -226,7 +226,7 @@ stages:
                 } 
 
                 $i++
-              } while ( ((!$resultUrl) -or (!$logsUrl) -or ($i -le 3) )
+              } while ( (!$resultUrl) -or (!$logsUrl) -or ($i -le 3) )
 
               # todo - timeout?
             } while ($result.status -ne "DONE")

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -163,7 +163,8 @@ stages:
             -loadTestId "$(loadTestId)" `
             -apiEndpoint "$(azureLoadTestDataPlaneURI)" `
             -testFileName "$(System.DefaultWorkingDirectory)/src/testing/loadtest-azure/scripts/catalog-test.jmx" `
-            -verbose:$true
+            -verbose:$true `
+            -wait:$true
 
       # start azure load test
       - task: AzureCLI@2

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -206,6 +206,8 @@ stages:
                           -testRunId "$(testRunId)"
               $testRunStatus = ($result).status
 
+              $result
+
               if ($result.status -eq "DONE") { # other states are FAILED, EXECUTING and CANCELLED
                 # test has successfully finished
                 echo "*** Test Run $(testRunId) was successfully completed. Status: $testRunStatus"

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -233,7 +233,7 @@ stages:
               # todo - timeout?
             } while ($result.status -ne "DONE")
 
-            echo "*** Test Run $(testRunId) was completed. Status: $testRunStatus"
+            echo "*** Test Run $(testRunId) was completed. Test Run Status: $testRunStatus Test Status: $($result.testResult)"
             echo "*** Portal URL: $($result.portalUrl)"
             
             # processing test data and publish it in azure devops

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -263,8 +263,8 @@ stages:
 
             if (Test-Path results/results.zip) {
               Expand-Archive -Path results/results.zip -DestinationPath results
-              $JMETER_RESULTS=results/testreport.csv
-              $JUNIT_RESULTS=output.xml
+              $JMETER_RESULTS="results/testreport.csv"
+              $JUNIT_RESULTS="output.xml"
               python3 junit-converter.py $JMETER_RESULTS $JUNIT_RESULTS
             } else {
               echo "Skipping result data conversion. results.zip was not found."

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -220,71 +220,11 @@ stages:
 
             echo "*** Test Run $(testRunId) was completed. Status: $testRunStatus"
             echo "*** Portal URL: $($result.portalUrl)"
-            
-            # processing test data and publish it in azure devops
-            # download results and logs - retry if empty
-            $i = 0
-            do {
-              $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
-              $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
-
-              if ( (!$resultUrl) -or (!$logsUrl) ) {
-                echo "*** Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty. Retry $i/3"
-                Start-Sleep -seconds 15
-              } else {
-                $i=3
-              }
-
-              $i++
-            } while ( $i -le 3 )
-
-            if ( ($resultUrl) -and ($logsUrl) ) {
-              New-Item -Path results -ItemType "directory"
-              echo "*** Download resultsUrl"
-              Invoke-WebRequest $resultUrl -OutFile "results/results.zip"
-              echo "*** Download logsUrl"
-              Invoke-WebRequest $logsUrl -OutFile "results/logs.zip"
-            } else {
-              throw "*** ERROR: Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty."
-            }
 
             # throw an error when testResult is FAILED
             if ($result.testResult -eq "FAILED") {
               throw "*** ERROR: Test result for run $($result.testRunId) is 'FAILED'. Test did not match the defined test criteria."
             }
-
-      - task: PowerShell@2
-        displayName: 'RESULTS: Convert JMeter Results to JUnit Format'
-        condition: succeeded()
-        inputs:
-          targetType: inline
-          script: |
-            wget https://raw.githubusercontent.com/Azure-Samples/jmeter-aci-terraform/main/scripts/jtl_junit_converter.py -O $(System.DefaultWorkingDirectory)/junit-converter.py
-
-            if (Test-Path results/results.zip) {
-              Expand-Archive -Path results/results.zip -DestinationPath results
-              $JMETER_RESULTS=results/testreport.csv
-              $JUNIT_RESULTS=output.xml
-              python3 junit-converter.py $JMETER_RESULTS $JUNIT_RESULTS
-            } else {
-              echo "Skipping result data conversion. results.zip was not found."
-            }
-            
-        
-      - task: PublishTestResults@2
-        displayName: 'RESULTS: Publish Load Testing Results'
-        condition: succeeded()
-        inputs:
-          testResultsFormat: 'JUnit'
-          testResultsFiles: 'output.xml'
-          failTaskOnFailedTests: false
-
-      # publish load test results as pipeline artifacts in azure devops
-      - task: PublishBuildArtifacts@1
-        condition: succeeded() 
-        inputs:
-          artifactName: 'loadtest'
-          pathToPublish: '$(System.DefaultWorkingDirectory)/results'
 
     # All of the next tasks are only applicable in headless mode
     - ${{ if eq(parameters.destroyInfra, 'true') }}:

--- a/.ado/pipelines/templates/stages-loadtest-azure.yaml
+++ b/.ado/pipelines/templates/stages-loadtest-azure.yaml
@@ -226,23 +226,27 @@ stages:
             # processing test data and publish it in azure devops
             # download results and logs - retry if empty
             if ( (!$resultUrl) -or (!$logsUrl) ) {
+            echo "*** Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty. Retrying.."
             
               $i = 0
               do {
-                $result = $(System.DefaultWorkingDirectory)/src/testing/loadtest-azure/scripts/loadtest-get-run.ps1 `
+                $outputArtifacts = ($(System.DefaultWorkingDirectory)/src/testing/loadtest-azure/scripts/loadtest-get-run.ps1 `
                   -apiEndpoint "$(azureLoadTestDataPlaneURI)" `
                   -apiVersion "$(azureLoadTestApiVersion)" `
-                  -testRunId "$(testRunId)"
-                $resultUrl = ($result).testArtifacts.outputArtifacts.resultUrl.url
-                $logsUrl = ($result).testArtifacts.outputArtifacts.logsUrl.url
+                  -testRunId "$(testRunId)").testArtifacts.outputArtifacts
+                $resultUrl = ($outputArtifacts).resultUrl.url
+                $logsUrl = ($outputArtifacts).logsUrl.url
 
                 if ( (!$resultUrl) -or (!$logsUrl) ) {
                   echo "*** Either logsUrl ($logsUrl) or resultUrl ($resultUrl) is empty. Retry $i/3"
                   Start-Sleep -seconds 15
-                } 
+                } else {
+                  echo "*** Received logsUrl ($logsUrl)
+                  echo "*** Received resultUrl ($resultUrl)"
+                }
 
                 $i++
-              } while ( ((!$resultUrl) -or (!$logsUrl)) -and ($i -le 3) )
+              } while ( $i -le 3 )
             }
 
             if ( ($resultUrl) -and ($logsUrl) ) {

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Owners of repository
-* @calcof @azure/alwayson-vteam
+* @calcof @azure/azure-mission-critical

--- a/src/testing/loadtest-azure/scripts/common.ps1
+++ b/src/testing/loadtest-azure/scripts/common.ps1
@@ -1,11 +1,12 @@
-$tenantId = az account show -o tsv --query 'tenantId'
-$subscriptionId = az account show -o tsv --query 'id'
+$tenantId = az account show --output tsv --query 'tenantId'
+$subscriptionId = az account show --output tsv --query 'id'
 
-$accessToken = az account get-access-token -o tsv `
+$accessToken = az account get-access-token `
+                        --output tsv `
                         --subscription $subscriptionId `
                         --query 'accessToken' `
                         --resource https://loadtest.azure-dev.com
-$accessTokenHeader = "Authorization=Bearer " + $accessToken
+$accessTokenHeader = "Authorization=Bearer {0}" -f $accessToken
 
 # Write access token to file as otherwise HTTP request too long to use az rest in Powershell
 $accessTokenFileName = "./accesstoken.txt"

--- a/src/testing/loadtest-azure/scripts/file-upload-to-loadtest.ps1
+++ b/src/testing/loadtest-azure/scripts/file-upload-to-loadtest.ps1
@@ -1,7 +1,6 @@
 # file-upload-to-loadtest.ps1 | Upload files (jmx and others) to a load test
 param
 (
-  # Load Test Id
   [Parameter(Mandatory = $true)]
   [string] $loadTestId,
 
@@ -9,7 +8,7 @@ param
   [Parameter(Mandatory = $true)]
   [string] $apiEndpoint,
 
-  # Load Test data plane api version
+  # optional - load test data plane api version
   [string] $apiVersion = "2022-06-01-preview",
 
   # Filename to upload
@@ -19,7 +18,7 @@ param
   # Test File ID is auto-generated when not set (default)
   [string] $testFileId = (New-Guid).toString(),
 
-  # if set to true script will set pipeline variables
+  # optional - expose outputs as pipeline variables
   [bool] $pipeline = $false,
 
   # if set to true script will wait till file was validated

--- a/src/testing/loadtest-azure/scripts/file-upload-to-loadtest.ps1
+++ b/src/testing/loadtest-azure/scripts/file-upload-to-loadtest.ps1
@@ -74,7 +74,7 @@ if($wait) {
        Write-Verbose "*** File $($fileStatus.fileId) was successfully validated."
     }
 
-  } while ($fileStatus.validationStatus -ne "VALIDATION_SUCCESS" )
+  } while ($fileStatus.validationStatus -eq "VALIDATION_INITIATED" )
 }
 
 Remove-Item $accessTokenFileName

--- a/src/testing/loadtest-azure/scripts/file-upload-to-loadtest.ps1
+++ b/src/testing/loadtest-azure/scripts/file-upload-to-loadtest.ps1
@@ -64,7 +64,7 @@ if($wait) {
 
   do {
 
-    $fileStatus = (./loadtest-get-files.ps1 -apiEndpoint $apiEndpoint `
+    $fileStatus = (& $PSScriptRoot\loadtest-get-files.ps1 -apiEndpoint $apiEndpoint `
                             -loadTestId $loadTestId `
                             -fileId $($result.fileId) `
                             -keepToken $true)

--- a/src/testing/loadtest-azure/scripts/file-upload-to-loadtest.ps1
+++ b/src/testing/loadtest-azure/scripts/file-upload-to-loadtest.ps1
@@ -68,8 +68,8 @@ if($wait) {
                             -fileId $($result.fileId) `
                             -keepToken $true)
     if ($fileStatus.validationStatus -ne "VALIDATION_SUCCESS") {
-      Write-Verbose "*** Waiting another 30s for file validation to complete $($fileStatus.validationStatus)"
-      Start-Sleep -seconds 30
+      Write-Verbose "*** Waiting another 10s for file validation to complete $($fileStatus.validationStatus)"
+      Start-Sleep -seconds 10
     } else {
        Write-Verbose "*** File $($fileStatus.fileId) was successfully validated."
     }

--- a/src/testing/loadtest-azure/scripts/file-upload-to-loadtest.ps1
+++ b/src/testing/loadtest-azure/scripts/file-upload-to-loadtest.ps1
@@ -64,10 +64,10 @@ if($wait) {
 
   do {
 
-    $fileStatus = ./loadtest-get-files.ps1 -apiEndpoint $apiEndpoint `
+    $fileStatus = (./loadtest-get-files.ps1 -apiEndpoint $apiEndpoint `
                             -loadTestId $loadTestId `
                             -fileId $($result.fileId) `
-                            -keepToken $true
+                            -keepToken $true)
     if ($fileStatus.validationStatus -ne "VALIDATION_SUCCESS") {
       Write-Verbose "*** Waiting another 30s for file validation to complete $($fileStatus.validationStatus)"
       Start-Sleep -seconds 30

--- a/src/testing/loadtest-azure/scripts/file-upload-to-loadtest.ps1
+++ b/src/testing/loadtest-azure/scripts/file-upload-to-loadtest.ps1
@@ -22,7 +22,7 @@ param
   [bool] $pipeline = $false,
 
   # if set to true script will wait till file was validated
-  [bool] $wait = $false 
+  [bool] $wait = $true
 )
 
 . "$PSScriptRoot/common.ps1"

--- a/src/testing/loadtest-azure/scripts/file-upload-to-loadtest.ps1
+++ b/src/testing/loadtest-azure/scripts/file-upload-to-loadtest.ps1
@@ -79,3 +79,5 @@ if($wait) {
 }
 
 Remove-Item $accessTokenFileName
+
+Write-Verbose "*** File $($fileStatus.filename) ($($fileStatus.fileId)) successfully uploaded to load test $loadTestId."

--- a/src/testing/loadtest-azure/scripts/file-verify.ps1
+++ b/src/testing/loadtest-azure/scripts/file-verify.ps1
@@ -14,7 +14,7 @@ param
 
 . "$PSScriptRoot/common.ps1"
 
-$urlRoot = "https://" + $apiEndpoint + "/file/" + $testFileName + ":validate"
+$urlRoot = "https://{0}/file/{1}:validate" -f $apiEndpoint, $testFileName
 
 # Secure string to use access token with Invoke-RestMethod in Powershell
 $accessTokenSecure = ConvertTo-SecureString -String $accessToken -AsPlainText -Force

--- a/src/testing/loadtest-azure/scripts/loadtest-create.ps1
+++ b/src/testing/loadtest-azure/scripts/loadtest-create.ps1
@@ -92,7 +92,7 @@ if ($passFailCriteria) {
 
 $body | Out-File $testDataFileName -Encoding utf8
 
-$urlRoot = "https://" + $apiEndpoint + "/loadtests/" + $loadTestId
+$urlRoot = "https://{0}/loadtests/{1}" -f $apiEndpoint, $loadTestId
 Write-Verbose "*** Load test service data plane: $urlRoot"
 
 # Create a new load test resource or update existing, if loadTestId already exists

--- a/src/testing/loadtest-azure/scripts/loadtest-create.ps1
+++ b/src/testing/loadtest-azure/scripts/loadtest-create.ps1
@@ -10,12 +10,15 @@ param
   # Load Test Description shown in Azure Portal
   [string] $loadTestDescription,
   
+  # Load Test target URL
   [Parameter(Mandatory = $true)]
   [string] $loadTestTargetUrl,
 
+  # Number of User threads
   [Parameter(Mandatory = $true)]
   [int] $loadTestUserThreads,
 
+  # Load test run duration
   [Parameter(Mandatory = $true)]
   [int] $loadTestDurationSeconds,
 
@@ -26,11 +29,13 @@ param
   [Parameter(Mandatory=$true)]
   [string] $apiEndpoint,
 
+  # parameter to handover a json file with test criteria
   [string] $passFailCriteria,
 
   # Load Test data plane api version
   [string] $apiVersion = "2022-06-01-preview",
 
+  # optional - expose pipeline variables
   [bool] $pipeline = $false
 )
 
@@ -102,7 +107,7 @@ az rest --url $urlRoot `
   --headers ('@' + $accessTokenFileName) "Content-Type=application/merge-patch+json" `
   --url-parameters testId=$loadTestId api-version=$apiVersion `
   --body ('@' + $testDataFileName) `
-  -o none $verbose 
+  --output none $verbose 
 
 # Outputs and exports for pipeline usage
 if($pipeline) {

--- a/src/testing/loadtest-azure/scripts/loadtest-create.ps1
+++ b/src/testing/loadtest-azure/scripts/loadtest-create.ps1
@@ -10,7 +10,6 @@ param
   # Load Test Description shown in Azure Portal
   [string] $loadTestDescription,
   
-  # Load Test target URL
   [Parameter(Mandatory = $true)]
   [string] $loadTestTargetUrl,
 
@@ -18,7 +17,7 @@ param
   [Parameter(Mandatory = $true)]
   [int] $loadTestUserThreads,
 
-  # Load test run duration
+  # Load test run duration (in seconds)
   [Parameter(Mandatory = $true)]
   [int] $loadTestDurationSeconds,
 
@@ -32,10 +31,10 @@ param
   # parameter to handover a json file with test criteria
   [string] $passFailCriteria,
 
-  # Load Test data plane api version
+  # optional - load test data plane api version
   [string] $apiVersion = "2022-06-01-preview",
 
-  # optional - expose pipeline variables
+  # optional - expose outputs as pipeline variables
   [bool] $pipeline = $false
 )
 

--- a/src/testing/loadtest-azure/scripts/loadtest-delete.ps1
+++ b/src/testing/loadtest-azure/scripts/loadtest-delete.ps1
@@ -19,7 +19,7 @@ if (!$loadTestId) {
 
 . ./common.ps1
 
-$urlRoot = "https://" + $apiEndpoint + "/loadtests/" + "$loadTestId"
+$urlRoot = "https://{0}/loadtests/{1}" -f $apiEndpoint,$loadTestId
 
 az rest --url $urlRoot `
   --method DELETE `

--- a/src/testing/loadtest-azure/scripts/loadtest-delete.ps1
+++ b/src/testing/loadtest-azure/scripts/loadtest-delete.ps1
@@ -1,7 +1,6 @@
 # loadtest-delete.ps1 | Delete a load test
 param
 (
-  # Load Test Id
   [Parameter(Mandatory=$true)]
   [string] $loadTestId,
   
@@ -9,7 +8,7 @@ param
   [Parameter(Mandatory=$true)]
   [string] $apiEndpoint,
 
-  # Load Test data plane api version
+  # optional - load test data plane api version
   [string] $apiVersion = "2022-06-01-preview"
 )
 

--- a/src/testing/loadtest-azure/scripts/loadtest-get-files.ps1
+++ b/src/testing/loadtest-azure/scripts/loadtest-get-files.ps1
@@ -12,18 +12,31 @@ param
   # Load Test data plane api version
   [string] $apiVersion = "2022-06-01-preview",
 
+  # optional - request an individual file via its fileId
+  [string] $fileId,
+
+  # optional - keep access token when used embedded
+  [bool] $keepToken = $false,
+
   [int] $maxPageSize
 )
 
 . "$PSScriptRoot/common.ps1"
 
-$urlRoot = "https://" + $apiEndpoint + "/loadtests/" + $loadTestId + "/files"
+$urlRoot = "https://{0}/loadtests/{1}/files" -f $apiEndpoint, $loadTestId
+
+if ($fileId) {
+  $urlRoot = "{0}/{1}" -f $urlRoot,$fileId
+}
 
 az rest --url $urlRoot `
   --method GET `
   --skip-authorization-header `
   --headers ('@' + $accessTokenFileName) `
   --url-parameters api-version=$apiVersion maxPageSize=$maxPageSize `
-  $verbose
+  $verbose --output json | convertFrom-Json
 
-Remove-Item $accessTokenFileName
+if (!$keepToken) {
+  # delete accessToken when $keepToken is set to $false (default)
+  Remove-Item $accessTokenFileName
+}

--- a/src/testing/loadtest-azure/scripts/loadtest-get-files.ps1
+++ b/src/testing/loadtest-azure/scripts/loadtest-get-files.ps1
@@ -1,7 +1,6 @@
 # loadtest-get-files.ps1 | List all files uploaded to a load test
 param
 (
-  # Load Test Id
   [Parameter(Mandatory=$true)]
   [string] $loadTestId,
   
@@ -9,7 +8,7 @@ param
   [Parameter(Mandatory=$true)]
   [string] $apiEndpoint,
 
-  # Load Test data plane api version
+  # optional - load test data plane api version
   [string] $apiVersion = "2022-06-01-preview",
 
   # optional - request an individual file via its fileId

--- a/src/testing/loadtest-azure/scripts/loadtest-get-results.ps1
+++ b/src/testing/loadtest-azure/scripts/loadtest-get-results.ps1
@@ -1,6 +1,5 @@
 param
 (
-  # Load Test Id
   [Parameter(Mandatory=$true)]
   [string] $loadTestId,
   
@@ -8,7 +7,7 @@ param
   [Parameter(Mandatory=$true)]
   [string] $apiEndpoint,
 
-  # Load Test data plane api version
+  # optional - load test data plane api version
   [string] $apiVersion = "2022-06-01-preview",
 
   [string] $testRunId

--- a/src/testing/loadtest-azure/scripts/loadtest-get-run.ps1
+++ b/src/testing/loadtest-azure/scripts/loadtest-get-run.ps1
@@ -1,7 +1,6 @@
 # loadtest-get-run.ps1 | Retrieve details from a load test run
 param
 (
-  # Load Test run id
   [Parameter(Mandatory=$true)]
   [string] $testRunId,
 
@@ -9,7 +8,7 @@ param
   [Parameter(Mandatory=$true)]
   [string] $apiEndpoint,
   
-  # Load Test data plane api version
+  # optional - load test data plane api version
   [string] $apiVersion = "2022-06-01-preview"
 )
 

--- a/src/testing/loadtest-azure/scripts/loadtest-get-run.ps1
+++ b/src/testing/loadtest-azure/scripts/loadtest-get-run.ps1
@@ -15,7 +15,7 @@ param
 
 . "$PSScriptRoot/common.ps1"
 
-$urlRoot = "https://" + $apiEndpoint + "/testruns/" + $testRunId
+$urlRoot = "https://{0}/testruns/{1}" -f $apiEndpoint, $testRunId
 
 $url = $urlRoot + "?api-version=" + $apiVersion
 

--- a/src/testing/loadtest-azure/scripts/loadtest-run.ps1
+++ b/src/testing/loadtest-azure/scripts/loadtest-run.ps1
@@ -10,7 +10,7 @@ param
   [string] $apiEndpoint,
 
   # Load Test data plane api version
-  [string] $apiVersion = "2021-07-01-preview",
+  [string] $apiVersion = "2022-06-01-preview",
 
   # Load Test run displayname
   [Parameter(Mandatory=$true)]

--- a/src/testing/loadtest-azure/scripts/loadtest-run.ps1
+++ b/src/testing/loadtest-azure/scripts/loadtest-run.ps1
@@ -1,7 +1,6 @@
 # loadtest-run.ps1 | Execute a load test run
 param
 (
-  # Load Test Id
   [Parameter(Mandatory=$true)]
   [string] $loadTestId,
   
@@ -9,7 +8,7 @@ param
   [Parameter(Mandatory=$true)]
   [string] $apiEndpoint,
 
-  # Load Test data plane api version
+  # optional - load test data plane api version
   [string] $apiVersion = "2022-06-01-preview",
 
   # Load Test run displayname
@@ -18,8 +17,11 @@ param
 
   # Load test run description
   [string] $testRunDescription,
+  
   [int] $testRunVUsers = 1,
-  [bool]$pipeline = $False 
+
+  # optional - expose outputs as pipeline variables
+  [bool] $pipeline = $false
 )
 
 . "$PSScriptRoot/common.ps1"

--- a/src/testing/loadtest-azure/scripts/loadtest-run.ps1
+++ b/src/testing/loadtest-azure/scripts/loadtest-run.ps1
@@ -48,7 +48,7 @@ function GetTestRunBody {
 }
 
 $testRunId = (New-Guid).toString()
-$urlRoot = "https://" + $apiEndpoint + "/testruns/" + $testRunId
+$urlRoot = "https://{0}/testruns/{1}"  -f $apiEndpoint,$testRunId
 Write-Verbose "*** Load test service data plane: $urlRoot"
 
 # Prep load test run body
@@ -60,7 +60,7 @@ $testRunData = GetTestRunBody `
     -vusers $testRunVUsers
 
 # Following is to get Invoke-RestMethod to work
-$url = $urlRoot + "?api-version=" + $apiVersion # + "&tenantId=" + $tenantId
+$url = $urlRoot + "?api-version=" + $apiVersion
 
 $header = @{
     'Content-Type'='application/merge-patch+json'

--- a/src/testing/loadtest-azure/scripts/loadtests-get.ps1
+++ b/src/testing/loadtest-azure/scripts/loadtests-get.ps1
@@ -1,7 +1,6 @@
 # loadtests-get.ps1 | List existing load tests
 param
 (
-  # Load Test Id
   [Parameter(Mandatory=$true)]
   [string] $loadTestId,
   
@@ -9,8 +8,8 @@ param
   [Parameter(Mandatory=$true)]
   [string] $apiEndpoint,
 
-  # Load Test data plane api version
-  [string] $apiVersion = "2022-06-01-preview",
+  # optional - expose outputs as pipeline variables
+  [bool] $pipeline = $false
 
   [int] $maxPageSize
 )

--- a/src/testing/loadtest-azure/scripts/loadtests-get.ps1
+++ b/src/testing/loadtest-azure/scripts/loadtests-get.ps1
@@ -17,7 +17,7 @@ param
 
 . "$PSScriptRoot/common.ps1"
 
-$urlRoot = "https://" + $apiEndpoint + "/loadtests/" + $loadTestId
+$urlRoot = "https://{0}/loadtests/{1}"  -f $apiEndpoint,$loadTestId
 
 az rest --url $urlRoot `
   --method GET `


### PR DESCRIPTION
This PR bumps the used data plane API version to `2022-06-01-preview`. The previously used API version `2021-07-01-preview` is deprecated and not available anymore.

The new API version required some changes to make the embedded LT work again. This includes to wait for the uploaded JMX file to be successfully validated before the LT run can be executed/started. This is implemented via a new (optional) `wait` parameter for `file-upload-to-loadtest.ps1`:

<img width="978" alt="image" src="https://user-images.githubusercontent.com/17407022/200783205-ea4b0dd4-1408-4904-816a-c9a532f9c6da.png">

Setting this parameter to `$true` will wait till the `validationStatus` is `VALIDATION_SUCCESS`.
