### PR TITLE
Update Clean-StaleResources.ps1

### DIFF
--- a/src/ops/scripts/Clean-StaleResources.ps1
+++ b/src/ops/scripts/Clean-StaleResources.ps1
@@ -22,7 +22,7 @@ function Remove-SavedLogAnalyticsQueries {
       Write-Host "*** Looking for saved searches in workspace $($workspace.name) in category 'HealthModel'"
 
       # List all saved searches in the workspace of category "HealthModel" (those are our saved queries)
-      $savedSearches = az monitor log-analytics workspace saved-search list --resource-group $workspace.resourceGroup --workspace-name $workspace.name --query "value[?category=='HealthModel']" | ConvertFrom-Json
+      $savedSearches = az monitor log-analytics workspace saved-search list --resource-group $workspace.resourceGroup --workspace-name $workspace.name --query "[?category=='HealthModel']" | ConvertFrom-Json
 
       foreach($search in $savedSearches)
       {


### PR DESCRIPTION
The `Remove-SavedLogAnalyticsQueries` stopped working. Small change to fix it. Tested it in cloud shell:

```
*** Looking for saved searches in workspace afe2e19f9-westeurop-log in category 'HealthModel'
Deleting saved search: addcommentuserflowhealthscore
Deleting saved search: aksclusterhealthscore
Deleting saved search: aksclusterhealthstatus
Deleting saved search: backgroundprocessorhealthscore
Deleting saved search: backgroundprocessorhealthstatus
Deleting saved search: backgroundprocessorslo
Deleting saved search: catalogservicehealthscore
Deleting saved search: catalogservicehealthstatus
Deleting saved search: catalogserviceslo
Deleting saved search: checkpointstoragehealthscore
Deleting saved search: checkpointstoragehealthstatus
Deleting saved search: eventhubhealthscore
Deleting saved search: eventhubhealthstatus
Deleting saved search: keyvaulthealthscore
Deleting saved search: keyvaulthealthstatus
Deleting saved search: listcatalogitemsuserflowhealthscore
Deleting saved search: publicblobstoragehealthscore
Deleting saved search: publicblobstoragehealthstatus
Deleting saved search: showstaticcontentuserflowhealthscore
Deleting saved search: stamphealthscore
```