### PR TITLE
bump version

### DIFF
--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -5,11 +5,11 @@ variables:
   value: 'foundational-online'
 
 - name: 'terraformVersion'    # Terraform Version
-  value: '1.3.2'
+  value: '1.3.5'
 - name: 'kubernetesVersion'   # kubernetes version used for aks clusters
-  value: '1.24.3'
+  value: '1.24.6'
 - name: 'helmVersion'         # helm package manager version
-  value: 'v3.9.4'
+  value: 'v3.10.2'
 - name: 'ingressNginxVersion' # nginx ingress controller helm chart version
   value: '4.2.5'
 - name: 'certManagerVersion'  # cert-manager helm chart version


### PR DESCRIPTION
This PR contains updates for some of the key components:

* Terraform from `1.3.2` to `1.3.5` https://github.com/hashicorp/terraform/releases/tag/v1.3.5
* K8s from `1.24.3` to `1.24.6`
* helm from `3.9.4` to `v3.10.2` https://github.com/helm/helm/releases/tag/v3.10.2