### PR TITLE
override swedencentral with westeurope

### DIFF
--- a/.ado/pipelines/config/variables-values-e2e.yaml
+++ b/.ado/pipelines/config/variables-values-e2e.yaml
@@ -11,7 +11,7 @@ variables:
 # Check which regions are valid. There is a list in /src/infra/README.md
 # If you are planning to run Chaos Studio experiments, make sure the first region in the list does support Azure Chaos Studio. Not all regions do yet
 - name: 'stampLocations'
-  value: '["uksouth"]'
+  value: '["swedencentral"]'
 
 # Terraform state variables
 - name:  'terraformResourceGroup'

--- a/src/infra/workload/releaseunit/modules/stamp/identities.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/identities.tf
@@ -1,8 +1,23 @@
+# regions where the creation of federated identity credentials is not supported on user-assigned managed identities
+# https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
+locals {
+  # regions where the creation of federated identity credentials is not supported on user-assigned managed identities
+  # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
+  unsupported_regions = [
+    "swedencentral",
+    "swedensouth",
+    "germanynorth",
+    "switzerlandwest",
+    "eastasia",
+    "qatarcentral"
+  ]
+}
+
 # managed identity used for catalogservice
 resource "azurerm_user_assigned_identity" "catalogservice" {
   # temporary workaround while the creation of federated identity credentials is not supported on user-assigned managed identities in some regions
   # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
-  location            = contains(locals.unsupported_regions, azurerm_resource_group.stamp.location) ? "westeurope" : azurerm_resource_group.stamp.location
+  location            = contains(local.unsupported_regions, azurerm_resource_group.stamp.location) ? "westeurope" : azurerm_resource_group.stamp.location
   name                = "catalogservice"
   resource_group_name = azurerm_resource_group.stamp.name
 }
@@ -20,7 +35,7 @@ resource "azurerm_federated_identity_credential" "catalogservice" {
 resource "azurerm_user_assigned_identity" "healthservice" {
   # temporary workaround while the creation of federated identity credentials is not supported on user-assigned managed identities in some regions
   # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
-  location            = contains(locals.unsupported_regions, azurerm_resource_group.stamp.location) ? "westeurope" : azurerm_resource_group.stamp.location
+  location            = contains(local.unsupported_regions, azurerm_resource_group.stamp.location) ? "westeurope" : azurerm_resource_group.stamp.location
   name                = "healthservice"
   resource_group_name = azurerm_resource_group.stamp.name
 }
@@ -38,7 +53,7 @@ resource "azurerm_federated_identity_credential" "healthservice" {
 resource "azurerm_user_assigned_identity" "backgroundprocessor" {
   # temporary workaround while the creation of federated identity credentials is not supported on user-assigned managed identities in some regions
   # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
-  location            = contains(locals.unsupported_regions, azurerm_resource_group.stamp.location) ? "westeurope" : azurerm_resource_group.stamp.location
+  location            = contains(local.unsupported_regions, azurerm_resource_group.stamp.location) ? "westeurope" : azurerm_resource_group.stamp.location
   name                = "backgroundprocessor"
   resource_group_name = azurerm_resource_group.stamp.name
 }

--- a/src/infra/workload/releaseunit/modules/stamp/identities.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/identities.tf
@@ -1,8 +1,14 @@
+# regions where the creation of federated identity credentials is not supported on user-assigned managed identities
+# https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
+locals {
+  unsupported_region = ["swedencentral", "swedensouth", "germanynorth"]
+}
+
 # managed identity used for catalogservice
 resource "azurerm_user_assigned_identity" "catalogservice" {
-  # creation of federated identity credentials is not supported on user-assigned managed identities
+  # temporary workaround while the creation of federated identity credentials is not supported on user-assigned managed identities in some regions
   # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
-  location            = azurerm_resource_group.stamp.location == "swedencentral" ? "westeurope" : azurerm_resource_group.stamp.location
+  location            = contains(locals.unsupported_region, azurerm_resource_group.stamp.location) ? "westeurope" : azurerm_resource_group.stamp.location
   name                = "catalogservice"
   resource_group_name = azurerm_resource_group.stamp.name
 }
@@ -18,9 +24,9 @@ resource "azurerm_federated_identity_credential" "catalogservice" {
 
 # managed identity used for healthservice
 resource "azurerm_user_assigned_identity" "healthservice" {
-  # creation of federated identity credentials is not supported on user-assigned managed identities
+  # temporary workaround while the creation of federated identity credentials is not supported on user-assigned managed identities in some regions
   # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
-  location            = azurerm_resource_group.stamp.location == "swedencentral" ? "westeurope" : azurerm_resource_group.stamp.location
+  location            = contains(locals.unsupported_region, azurerm_resource_group.stamp.location) ? "westeurope" : azurerm_resource_group.stamp.location
   name                = "healthservice"
   resource_group_name = azurerm_resource_group.stamp.name
 }
@@ -36,9 +42,9 @@ resource "azurerm_federated_identity_credential" "healthservice" {
 
 # managed identity used for backgroundprocessor
 resource "azurerm_user_assigned_identity" "backgroundprocessor" {
-  # creation of federated identity credentials is not supported on user-assigned managed identities
+  # temporary workaround while the creation of federated identity credentials is not supported on user-assigned managed identities in some regions
   # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
-  location            = azurerm_resource_group.stamp.location == "swedencentral" ? "westeurope" : azurerm_resource_group.stamp.location
+  location            = contains(locals.unsupported_region, azurerm_resource_group.stamp.location) ? "westeurope" : azurerm_resource_group.stamp.location
   name                = "backgroundprocessor"
   resource_group_name = azurerm_resource_group.stamp.name
 }

--- a/src/infra/workload/releaseunit/modules/stamp/identities.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/identities.tf
@@ -4,12 +4,18 @@ locals {
   # regions where the creation of federated identity credentials is not supported on user-assigned managed identities
   # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
   unsupported_regions = [
-    "swedencentral",
-    "swedensouth",
     "germanynorth",
+    "swedensouth",
+    "swedencentral",
     "switzerlandwest",
+    "brazilsoutheast",
     "eastasia",
-    "qatarcentral"
+    "southeastasia",
+    "southafricawest",
+    "qatarcentral",
+    "australiacentral",
+    "australiacentral2",
+    "norwaywest"
   ]
 }
 

--- a/src/infra/workload/releaseunit/modules/stamp/identities.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/identities.tf
@@ -1,14 +1,3 @@
-# regions where the creation of federated identity credentials is not supported on user-assigned managed identities
-# https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
-locals {
-  unsupported_regions = [
-    "swedencentral", "swedensouth",
-    "germanynorth",
-    "switzerlandwest",
-    "eastasia",
-  "qatarcentral"]
-}
-
 # managed identity used for catalogservice
 resource "azurerm_user_assigned_identity" "catalogservice" {
   # temporary workaround while the creation of federated identity credentials is not supported on user-assigned managed identities in some regions

--- a/src/infra/workload/releaseunit/modules/stamp/identities.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/identities.tf
@@ -1,4 +1,3 @@
-# regions where the creation of federated identity credentials is not supported on user-assigned managed identities
 locals {
   # regions where the creation of federated identity credentials is not supported on user-assigned managed identities
   # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities

--- a/src/infra/workload/releaseunit/modules/stamp/identities.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/identities.tf
@@ -1,14 +1,19 @@
 # regions where the creation of federated identity credentials is not supported on user-assigned managed identities
 # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
 locals {
-  unsupported_region = ["swedencentral", "swedensouth", "germanynorth"]
+  unsupported_regions = [
+    "swedencentral", "swedensouth", 
+    "germanynorth",
+    "switzerlandwest",
+    "eastasia",
+    "qatarcentral"]
 }
 
 # managed identity used for catalogservice
 resource "azurerm_user_assigned_identity" "catalogservice" {
   # temporary workaround while the creation of federated identity credentials is not supported on user-assigned managed identities in some regions
   # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
-  location            = contains(locals.unsupported_region, azurerm_resource_group.stamp.location) ? "westeurope" : azurerm_resource_group.stamp.location
+  location            = contains(locals.unsupported_regions, azurerm_resource_group.stamp.location) ? "westeurope" : azurerm_resource_group.stamp.location
   name                = "catalogservice"
   resource_group_name = azurerm_resource_group.stamp.name
 }
@@ -26,7 +31,7 @@ resource "azurerm_federated_identity_credential" "catalogservice" {
 resource "azurerm_user_assigned_identity" "healthservice" {
   # temporary workaround while the creation of federated identity credentials is not supported on user-assigned managed identities in some regions
   # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
-  location            = contains(locals.unsupported_region, azurerm_resource_group.stamp.location) ? "westeurope" : azurerm_resource_group.stamp.location
+  location            = contains(locals.unsupported_regions, azurerm_resource_group.stamp.location) ? "westeurope" : azurerm_resource_group.stamp.location
   name                = "healthservice"
   resource_group_name = azurerm_resource_group.stamp.name
 }
@@ -44,7 +49,7 @@ resource "azurerm_federated_identity_credential" "healthservice" {
 resource "azurerm_user_assigned_identity" "backgroundprocessor" {
   # temporary workaround while the creation of federated identity credentials is not supported on user-assigned managed identities in some regions
   # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
-  location            = contains(locals.unsupported_region, azurerm_resource_group.stamp.location) ? "westeurope" : azurerm_resource_group.stamp.location
+  location            = contains(locals.unsupported_regions, azurerm_resource_group.stamp.location) ? "westeurope" : azurerm_resource_group.stamp.location
   name                = "backgroundprocessor"
   resource_group_name = azurerm_resource_group.stamp.name
 }

--- a/src/infra/workload/releaseunit/modules/stamp/identities.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/identities.tf
@@ -1,5 +1,4 @@
 # regions where the creation of federated identity credentials is not supported on user-assigned managed identities
-# https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
 locals {
   # regions where the creation of federated identity credentials is not supported on user-assigned managed identities
   # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities

--- a/src/infra/workload/releaseunit/modules/stamp/identities.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/identities.tf
@@ -2,11 +2,11 @@
 # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
 locals {
   unsupported_regions = [
-    "swedencentral", "swedensouth", 
+    "swedencentral", "swedensouth",
     "germanynorth",
     "switzerlandwest",
     "eastasia",
-    "qatarcentral"]
+  "qatarcentral"]
 }
 
 # managed identity used for catalogservice

--- a/src/infra/workload/releaseunit/modules/stamp/identities.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/identities.tf
@@ -1,6 +1,8 @@
 # managed identity used for catalogservice
 resource "azurerm_user_assigned_identity" "catalogservice" {
-  location            = azurerm_resource_group.stamp.location
+  # creation of federated identity credentials is not supported on user-assigned managed identities
+  # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
+  location            = azurerm_resource_group.stamp.location == "swedencentral" ? "westeurope" : azurerm_resource_group.stamp.location
   name                = "catalogservice"
   resource_group_name = azurerm_resource_group.stamp.name
 }
@@ -16,7 +18,9 @@ resource "azurerm_federated_identity_credential" "catalogservice" {
 
 # managed identity used for healthservice
 resource "azurerm_user_assigned_identity" "healthservice" {
-  location            = azurerm_resource_group.stamp.location
+  # creation of federated identity credentials is not supported on user-assigned managed identities
+  # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
+  location            = azurerm_resource_group.stamp.location == "swedencentral" ? "westeurope" : azurerm_resource_group.stamp.location
   name                = "healthservice"
   resource_group_name = azurerm_resource_group.stamp.name
 }
@@ -32,7 +36,9 @@ resource "azurerm_federated_identity_credential" "healthservice" {
 
 # managed identity used for backgroundprocessor
 resource "azurerm_user_assigned_identity" "backgroundprocessor" {
-  location            = azurerm_resource_group.stamp.location
+  # creation of federated identity credentials is not supported on user-assigned managed identities
+  # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
+  location            = azurerm_resource_group.stamp.location == "swedencentral" ? "westeurope" : azurerm_resource_group.stamp.location
   name                = "backgroundprocessor"
   resource_group_name = azurerm_resource_group.stamp.name
 }

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -10,7 +10,7 @@ resource "azurerm_kubernetes_cluster" "stamp" {
 
   automatic_channel_upgrade = "node-image"
 
-  oidc_issuer_enabled = true
+  oidc_issuer_enabled       = true
   workload_identity_enabled = true
 
   maintenance_window {

--- a/src/infra/workload/releaseunit/modules/stamp/locals.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/locals.tf
@@ -8,4 +8,15 @@ locals {
   location_short = substr(var.location, 0, 9) # shortened location name used for resource naming
 
   global_resource_prefix = regex("^(.+)-global-rg$", var.global_resource_group_name)[0] # extract global resource prefix from the global resource group name
+
+  # regions where the creation of federated identity credentials is not supported on user-assigned managed identities
+  # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
+  unsupported_regions = [
+    "swedencentral",
+    "swedensouth",
+    "germanynorth",
+    "switzerlandwest",
+    "eastasia",
+    "qatarcentral"
+  ]
 }

--- a/src/infra/workload/releaseunit/modules/stamp/locals.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/locals.tf
@@ -9,14 +9,5 @@ locals {
 
   global_resource_prefix = regex("^(.+)-global-rg$", var.global_resource_group_name)[0] # extract global resource prefix from the global resource group name
 
-  # regions where the creation of federated identity credentials is not supported on user-assigned managed identities
-  # https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities
-  unsupported_regions = [
-    "swedencentral",
-    "swedensouth",
-    "germanynorth",
-    "switzerlandwest",
-    "eastasia",
-    "qatarcentral"
-  ]
+
 }

--- a/src/infra/workload/releaseunit/modules/stamp/locals.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/locals.tf
@@ -8,5 +8,4 @@ locals {
   location_short = substr(var.location, 0, 9) # shortened location name used for resource naming
 
   global_resource_prefix = regex("^(.+)-global-rg$", var.global_resource_group_name)[0] # extract global resource prefix from the global resource group name
-
 }

--- a/src/infra/workload/releaseunit/modules/stamp/locals.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/locals.tf
@@ -9,5 +9,4 @@ locals {
 
   global_resource_prefix = regex("^(.+)-global-rg$", var.global_resource_group_name)[0] # extract global resource prefix from the global resource group name
 
-
 }


### PR DESCRIPTION
creation of federated identity credentials is not supported on user-assigned managed identities
https://learn.microsoft.com/azure/active-directory/develop/workload-identity-federation-considerations#unsupported-regions-user-assigned-managed-identities

this PR contains a temporary workaround to override `swedencentral` with `westeurope` (for the identities only)