### PR TITLE
WIP - Onboard Managed Prometheus per stamp

### DIFF
--- a/src/infra/monitoring/grafana/terraform/globalresources/main.tf
+++ b/src/infra/monitoring/grafana/terraform/globalresources/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.34.0"
+      version = "3.37.0"
     }
   }
 

--- a/src/infra/monitoring/grafana/terraform/stamps/main.tf
+++ b/src/infra/monitoring/grafana/terraform/stamps/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.34.0"
+      version = "3.37.0"
     }
   }
 

--- a/src/infra/workload/globalresources/main.tf
+++ b/src/infra/workload/globalresources/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.34.0"
+      version = "3.37.0"
     }
     azapi = {
       source  = "Azure/azapi"

--- a/src/infra/workload/globalresources/main.tf
+++ b/src/infra/workload/globalresources/main.tf
@@ -27,6 +27,9 @@ provider "azurerm" {
   }
 }
 
+provider "azapi" {
+}
+
 resource "azurerm_resource_group" "global" {
   name     = "${local.prefix}-global-rg"
   location = local.location

--- a/src/infra/workload/globalresources/main.tf
+++ b/src/infra/workload/globalresources/main.tf
@@ -27,8 +27,7 @@ provider "azurerm" {
   }
 }
 
-provider "azapi" {
-}
+provider "azapi" {}
 
 resource "azurerm_resource_group" "global" {
   name     = "${local.prefix}-global-rg"

--- a/src/infra/workload/globalresources/main.tf
+++ b/src/infra/workload/globalresources/main.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "3.34.0"
     }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "1.1.0"
+    }
   }
 
   backend "azurerm" {

--- a/src/infra/workload/globalresources/modules/stamp_monitoring/datasources.tf
+++ b/src/infra/workload/globalresources/modules/stamp_monitoring/datasources.tf
@@ -1,3 +1,0 @@
-data "azurerm_resource_group" "monitoring" {
-  name = var.resource_group_name
-}

--- a/src/infra/workload/globalresources/modules/stamp_monitoring/datasources.tf
+++ b/src/infra/workload/globalresources/modules/stamp_monitoring/datasources.tf
@@ -1,0 +1,3 @@
+data "azurerm_resource_group" "monitoring" {
+  name = var.resource_group_name
+}

--- a/src/infra/workload/globalresources/modules/stamp_monitoring/main.tf
+++ b/src/infra/workload/globalresources/modules/stamp_monitoring/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.34.0"
+      version = "3.37.0"
     }
     azapi = {
       source  = "Azure/azapi"

--- a/src/infra/workload/globalresources/modules/stamp_monitoring/main.tf
+++ b/src/infra/workload/globalresources/modules/stamp_monitoring/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.34.0"
+    }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "1.1.0"
+    }
+  }
+}

--- a/src/infra/workload/globalresources/modules/stamp_monitoring/outputs.tf
+++ b/src/infra/workload/globalresources/modules/stamp_monitoring/outputs.tf
@@ -1,3 +1,7 @@
 output "log_analytics_workspace_id" {
   value = azurerm_log_analytics_workspace.stamp.workspace_id
 }
+
+output "azure_monitor_workspace_id" {
+  value = azapi_resource.prometheus.id
+}

--- a/src/infra/workload/globalresources/modules/stamp_monitoring/prometheus.tf
+++ b/src/infra/workload/globalresources/modules/stamp_monitoring/prometheus.tf
@@ -43,17 +43,6 @@ resource "azapi_resource" "prometheus" {
 #   principal_id         = azapi_resource.grafana.identity[0].principal_id
 # }
 
-resource "azapi_resource" "dataCollectionEndpoint" {
-  type      = "Microsoft.Insights/dataCollectionEndpoints@2021-09-01-preview"
-  name      = "${local.prefix}-${local.location_short}-prom-dce"
-  parent_id = var.resource_group_id
-  location  = var.location
-
-  body = jsonencode({
-    kind       = "Linux"
-    properties = {}
-  })
-}
 
 # resource "azapi_resource" "dataCollectionRuleAssociation" {
 #   schema_validation_enabled = false

--- a/src/infra/workload/globalresources/modules/stamp_monitoring/prometheus.tf
+++ b/src/infra/workload/globalresources/modules/stamp_monitoring/prometheus.tf
@@ -1,0 +1,109 @@
+resource "azapi_resource" "prometheus" {
+  type      = "microsoft.monitor/accounts@2021-06-03-preview"
+  name      = "${local.prefix}-prometheus"
+  parent_id = data.azurerm_resource_group.monitoring.id
+  location  = data.azurerm_resource_group.monitoring.location
+
+  response_export_values = ["*"]
+}
+
+# resource "azapi_resource" "grafana" {
+#   type      = "Microsoft.Dashboard/grafana@2022-08-01"
+#   name      = "${local.prefix}-grafana"
+#   parent_id = data.azurerm_resource_group.monitoring.id
+#   location  = data.azurerm_resource_group.monitoring.location
+
+#   identity {
+#     type = "SystemAssigned"
+#   }
+
+#   body = jsonencode({
+#     sku = {
+#       name = "Standard"
+#     }
+#     properties = {
+#       zoneRedundancy          = "Enabled"
+#       apiKey                  = "Disabled"
+#       deterministicOutboundIP = "Disabled"
+#       grafanaIntegrations = {
+#         azureMonitorWorkspaceIntegrations = [
+#           {
+#             azureMonitorWorkspaceResourceId = azapi_resource.prometheus.id
+#           }
+#         ]
+#       }
+#     }
+#   })
+# }
+
+# resource "azurerm_role_assignment" "grafana_monitoring_reader" {
+#   scope = azapi_resource.prometheus.id
+#   # scope                = "/subscriptions/${data.azurerm_subscription.current.subscription_id}"
+#   role_definition_name = "Monitoring Data Reader"
+#   principal_id         = azapi_resource.grafana.identity[0].principal_id
+# }
+
+resource "azapi_resource" "dataCollectionEndpoint" {
+  type      = "Microsoft.Insights/dataCollectionEndpoints@2021-09-01-preview"
+  name      = "${local.prefix}-${local.location_short}-prom-dce"
+  parent_id = data.azurerm_resource_group.monitoring.id
+  location  = data.azurerm_resource_group.monitoring.location
+
+  body = jsonencode({
+    kind       = "Linux"
+    properties = {}
+  })
+}
+
+resource "azapi_resource" "dataCollectionRule" {
+  schema_validation_enabled = false
+
+  type      = "Microsoft.Insights/dataCollectionRules@2021-09-01-preview"
+  name      = "${local.prefix}-${local.location_short}-prom-dcr"
+  parent_id = data.azurerm_resource_group.monitoring.id
+  location  = data.azurerm_resource_group.monitoring.location
+
+  body = jsonencode({
+    kind = "Linux"
+    properties = {
+      dataCollectionEndpointId = jsondecode(azapi_resource.prometheus.output).properties.defaultIngestionSettings.dataCollectionEndpointResourceId
+      dataFlows = [
+        {
+          destinations = ["MonitoringAccount1"]
+          streams      = ["Microsoft-PrometheusMetrics"]
+        }
+      ]
+      dataSources = {
+        prometheusForwarder = [
+          {
+            name               = "PrometheusDataSource"
+            streams            = ["Microsoft-PrometheusMetrics"]
+            labelIncludeFilter = {}
+          }
+        ]
+      }
+      destinations = {
+        monitoringAccounts = [
+          {
+            accountResourceId = azapi_resource.prometheus.id
+            name              = "MonitoringAccount1"
+          }
+        ]
+      }
+    }
+  })
+}
+
+# resource "azapi_resource" "dataCollectionRuleAssociation" {
+#   schema_validation_enabled = false
+#   type                      = "Microsoft.Insights/dataCollectionRuleAssociations@2021-09-01-preview"
+#   name                      = "${local.prefix}-prom-dcra"
+#   parent_id                 = azurerm_kubernetes_cluster.stamp.id
+#   location                  = azurerm_resource_group.stamp.location
+
+#   body = jsonencode({
+#     properties = {
+#       dataCollectionRuleId = jsondecode(azapi_resource.prometheus.output).properties.defaultIngestionSettings.dataCollectionRuleResourceId
+#     }
+#   })
+# }

--- a/src/infra/workload/globalresources/modules/stamp_monitoring/prometheus.tf
+++ b/src/infra/workload/globalresources/modules/stamp_monitoring/prometheus.tf
@@ -55,45 +55,6 @@ resource "azapi_resource" "dataCollectionEndpoint" {
   })
 }
 
-resource "azapi_resource" "dataCollectionRule" {
-  schema_validation_enabled = false
-
-  type      = "Microsoft.Insights/dataCollectionRules@2021-09-01-preview"
-  name      = "${local.prefix}-${local.location_short}-prom-dcr"
-  parent_id = var.resource_group_id
-  location  = var.location
-
-  body = jsonencode({
-    kind = "Linux"
-    properties = {
-      dataCollectionEndpointId = jsondecode(azapi_resource.prometheus.output).properties.defaultIngestionSettings.dataCollectionEndpointResourceId
-      dataFlows = [
-        {
-          destinations = ["MonitoringAccount1"]
-          streams      = ["Microsoft-PrometheusMetrics"]
-        }
-      ]
-      dataSources = {
-        prometheusForwarder = [
-          {
-            name               = "PrometheusDataSource"
-            streams            = ["Microsoft-PrometheusMetrics"]
-            labelIncludeFilter = {}
-          }
-        ]
-      }
-      destinations = {
-        monitoringAccounts = [
-          {
-            accountResourceId = azapi_resource.prometheus.id
-            name              = "MonitoringAccount1"
-          }
-        ]
-      }
-    }
-  })
-}
-
 # resource "azapi_resource" "dataCollectionRuleAssociation" {
 #   schema_validation_enabled = false
 #   type                      = "Microsoft.Insights/dataCollectionRuleAssociations@2021-09-01-preview"

--- a/src/infra/workload/globalresources/modules/stamp_monitoring/prometheus.tf
+++ b/src/infra/workload/globalresources/modules/stamp_monitoring/prometheus.tf
@@ -1,59 +1,8 @@
 resource "azapi_resource" "prometheus" {
   type      = "microsoft.monitor/accounts@2021-06-03-preview"
-  name      = "${local.prefix}-prometheus"
+  name      = "${local.prefix}-${local.location_short}-prometheus"
   parent_id = var.resource_group_id
   location  = var.location
 
   response_export_values = ["*"]
 }
-
-# resource "azapi_resource" "grafana" {
-#   type      = "Microsoft.Dashboard/grafana@2022-08-01"
-#   name      = "${local.prefix}-grafana"
-#   parent_id = var.resource_group_id
-#   location  = var.location
-
-#   identity {
-#     type = "SystemAssigned"
-#   }
-
-#   body = jsonencode({
-#     sku = {
-#       name = "Standard"
-#     }
-#     properties = {
-#       zoneRedundancy          = "Enabled"
-#       apiKey                  = "Disabled"
-#       deterministicOutboundIP = "Disabled"
-#       grafanaIntegrations = {
-#         azureMonitorWorkspaceIntegrations = [
-#           {
-#             azureMonitorWorkspaceResourceId = azapi_resource.prometheus.id
-#           }
-#         ]
-#       }
-#     }
-#   })
-# }
-
-# resource "azurerm_role_assignment" "grafana_monitoring_reader" {
-#   scope = azapi_resource.prometheus.id
-#   # scope                = "/subscriptions/${data.azurerm_subscription.current.subscription_id}"
-#   role_definition_name = "Monitoring Data Reader"
-#   principal_id         = azapi_resource.grafana.identity[0].principal_id
-# }
-
-
-# resource "azapi_resource" "dataCollectionRuleAssociation" {
-#   schema_validation_enabled = false
-#   type                      = "Microsoft.Insights/dataCollectionRuleAssociations@2021-09-01-preview"
-#   name                      = "${local.prefix}-prom-dcra"
-#   parent_id                 = azurerm_kubernetes_cluster.stamp.id
-#   location                  = azurerm_resource_group.stamp.location
-
-#   body = jsonencode({
-#     properties = {
-#       dataCollectionRuleId = jsondecode(azapi_resource.prometheus.output).properties.defaultIngestionSettings.dataCollectionRuleResourceId
-#     }
-#   })
-# }

--- a/src/infra/workload/globalresources/modules/stamp_monitoring/prometheus.tf
+++ b/src/infra/workload/globalresources/modules/stamp_monitoring/prometheus.tf
@@ -1,8 +1,8 @@
 resource "azapi_resource" "prometheus" {
   type      = "microsoft.monitor/accounts@2021-06-03-preview"
   name      = "${local.prefix}-prometheus"
-  parent_id = data.azurerm_resource_group.monitoring.id
-  location  = data.azurerm_resource_group.monitoring.location
+  parent_id = var.resource_group_id
+  location  = var.location
 
   response_export_values = ["*"]
 }
@@ -10,8 +10,8 @@ resource "azapi_resource" "prometheus" {
 # resource "azapi_resource" "grafana" {
 #   type      = "Microsoft.Dashboard/grafana@2022-08-01"
 #   name      = "${local.prefix}-grafana"
-#   parent_id = data.azurerm_resource_group.monitoring.id
-#   location  = data.azurerm_resource_group.monitoring.location
+#   parent_id = var.resource_group_id
+#   location  = var.location
 
 #   identity {
 #     type = "SystemAssigned"
@@ -46,8 +46,8 @@ resource "azapi_resource" "prometheus" {
 resource "azapi_resource" "dataCollectionEndpoint" {
   type      = "Microsoft.Insights/dataCollectionEndpoints@2021-09-01-preview"
   name      = "${local.prefix}-${local.location_short}-prom-dce"
-  parent_id = data.azurerm_resource_group.monitoring.id
-  location  = data.azurerm_resource_group.monitoring.location
+  parent_id = var.resource_group_id
+  location  = var.location
 
   body = jsonencode({
     kind       = "Linux"
@@ -60,8 +60,8 @@ resource "azapi_resource" "dataCollectionRule" {
 
   type      = "Microsoft.Insights/dataCollectionRules@2021-09-01-preview"
   name      = "${local.prefix}-${local.location_short}-prom-dcr"
-  parent_id = data.azurerm_resource_group.monitoring.id
-  location  = data.azurerm_resource_group.monitoring.location
+  parent_id = var.resource_group_id
+  location  = var.location
 
   body = jsonencode({
     kind = "Linux"

--- a/src/infra/workload/globalresources/modules/stamp_monitoring/variables.tf
+++ b/src/infra/workload/globalresources/modules/stamp_monitoring/variables.tf
@@ -13,6 +13,11 @@ variable "resource_group_name" {
   type        = string
 }
 
+variable "resource_group_id" {
+  description = "Resource Group Id"
+  type        = string
+}
+
 variable "azure_monitor_action_group_resource_id" {
   description = "Resource ID of a Azure Monitor action group to send alerts to"
   type        = string

--- a/src/infra/workload/globalresources/monitoring_stamp.tf
+++ b/src/infra/workload/globalresources/monitoring_stamp.tf
@@ -15,4 +15,8 @@ module "stamp_monitoring" {
   azure_monitor_action_group_resource_id = azurerm_monitor_action_group.main.id
   alerts_enabled                         = var.alerts_enabled
   default_tags                           = local.default_tags
+
+  depends_on = [
+    azurerm_resource_group.monitoring
+  ]
 }

--- a/src/infra/workload/globalresources/monitoring_stamp.tf
+++ b/src/infra/workload/globalresources/monitoring_stamp.tf
@@ -11,12 +11,9 @@ module "stamp_monitoring" {
 
   location                               = each.value
   prefix                                 = local.prefix
+  resource_group_id                      = azurerm_resource_group.monitoring.id
   resource_group_name                    = azurerm_resource_group.monitoring.name
   azure_monitor_action_group_resource_id = azurerm_monitor_action_group.main.id
   alerts_enabled                         = var.alerts_enabled
   default_tags                           = local.default_tags
-
-  depends_on = [
-    azurerm_resource_group.monitoring
-  ]
 }

--- a/src/infra/workload/releaseunit/main.tf
+++ b/src/infra/workload/releaseunit/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.34.0"
+      version = "3.37.0"
     }
     azapi = {
       source  = "Azure/azapi"

--- a/src/infra/workload/releaseunit/main.tf
+++ b/src/infra/workload/releaseunit/main.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "3.34.0"
     }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "1.1.0"
+    }
   }
 
   backend "azurerm" {}

--- a/src/infra/workload/releaseunit/main.tf
+++ b/src/infra/workload/releaseunit/main.tf
@@ -23,6 +23,8 @@ provider "azurerm" {
   }
 }
 
+provider "azapi" {}
+
 # Random API key which needs to be identical between all stamps
 resource "random_password" "api_key" {
   length  = 32

--- a/src/infra/workload/releaseunit/modules/stamp/datasources.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/datasources.tf
@@ -10,7 +10,7 @@ data "azurerm_resource_group" "monitoring" {
 }
 
 data "azapi_resource" "prometheus" {
-  name      = "${local.prefix}-prometheus"
+  name      = "${local.prefix}-${local.location_short}-prometheus"
   type      = "microsoft.monitor/accounts@2021-06-03-preview"
   parent_id = data.azurerm_resource_group.monitoring.id
   

--- a/src/infra/workload/releaseunit/modules/stamp/datasources.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/datasources.tf
@@ -5,6 +5,16 @@ data "azurerm_cosmosdb_account" "global" {
   resource_group_name = var.global_resource_group_name
 }
 
+data "azurerm_resource_group" "monitoring" {
+  name = var.monitoring_resource_group_name
+}
+
+data "azapi_resource" "prometheus" {
+  name      = "${local.prefix}-prometheus"
+  type      = "microsoft.monitor/accounts@2021-06-03-preview"
+  parent_id = data.azurerm_resource_group.monitoring.id
+}
+
 data "azurerm_container_registry" "global" {
   name                = var.acr_name
   resource_group_name = var.global_resource_group_name

--- a/src/infra/workload/releaseunit/modules/stamp/datasources.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/datasources.tf
@@ -13,6 +13,8 @@ data "azapi_resource" "prometheus" {
   name      = "${local.prefix}-prometheus"
   type      = "microsoft.monitor/accounts@2021-06-03-preview"
   parent_id = data.azurerm_resource_group.monitoring.id
+  
+  response_export_values = ["*"]
 }
 
 data "azurerm_container_registry" "global" {

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -10,6 +10,8 @@ resource "azurerm_kubernetes_cluster" "stamp" {
 
   automatic_channel_upgrade = "node-image"
 
+  monitor_metrics {}
+
   oidc_issuer_enabled       = true
   workload_identity_enabled = true
 

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -102,6 +102,20 @@ resource "azurerm_kubernetes_cluster_node_pool" "workload" {
   tags = var.default_tags
 }
 
+resource "azapi_resource" "dataCollectionRuleAssociation" {
+  schema_validation_enabled = false
+  type                      = "Microsoft.Insights/dataCollectionRuleAssociations@2021-09-01-preview"
+  name                      = "${local.prefix}-prom-dcra"
+  parent_id                 = azurerm_kubernetes_cluster.stamp.id
+  location                  = azurerm_resource_group.stamp.location
+
+  body = jsonencode({
+    properties = {
+      dataCollectionRuleId = jsondecode(data.azapi_resource.prometheus.output).properties.defaultIngestionSettings.dataCollectionRuleResourceId
+    }
+  })
+}
+
 ####################################### DIAGNOSTIC SETTINGS #######################################
 
 # Use this data source to fetch all available log and metrics categories. We then enable all of them

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -102,20 +102,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "workload" {
   tags = var.default_tags
 }
 
-resource "azapi_resource" "dataCollectionRuleAssociation" {
-  schema_validation_enabled = false
-  type                      = "Microsoft.Insights/dataCollectionRuleAssociations@2021-09-01-preview"
-  name                      = "${local.prefix}-prom-dcra"
-  parent_id                 = azurerm_kubernetes_cluster.stamp.id
-  location                  = azurerm_resource_group.stamp.location
-
-  body = jsonencode({
-    properties = {
-      dataCollectionRuleId = jsondecode(data.azapi_resource.prometheus.output).properties.defaultIngestionSettings.dataCollectionRuleResourceId
-    }
-  })
-}
-
 ####################################### DIAGNOSTIC SETTINGS #######################################
 
 # Use this data source to fetch all available log and metrics categories. We then enable all of them

--- a/src/infra/workload/releaseunit/modules/stamp/main.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.34.0"
+      version = "3.37.0"
     }
     azapi = {
       source  = "Azure/azapi"

--- a/src/infra/workload/releaseunit/modules/stamp/main.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/main.tf
@@ -1,3 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.34.0"
+    }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "1.1.0"
+    }
+  }
+}
+
 # Azure Resource Group used for all resources (per stamp)
 resource "azurerm_resource_group" "stamp" {
   name     = "${var.prefix}-stamp-${var.location}-rg"

--- a/src/infra/workload/releaseunit/modules/stamp/prometheus.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/prometheus.tf
@@ -1,0 +1,52 @@
+resource "azapi_resource" "dataCollectionRule" {
+  schema_validation_enabled = false
+
+  type      = "Microsoft.Insights/dataCollectionRules@2021-09-01-preview"
+  name      = "MSPROM-${azurerm_kubernetes_cluster.stamp.name}-${azurerm_kubernetes_cluster.stamp.location}"
+  parent_id = azurerm_kubernetes_cluster.stamp.id
+  location  = azurerm_resource_group.stamp.location
+
+  body = jsonencode({
+    kind = "Linux"
+    properties = {
+      dataCollectionEndpointId = jsondecode(data.azapi_resource.prometheus.output).properties.defaultIngestionSettings.dataCollectionEndpointResourceId
+      dataFlows = [
+        {
+          destinations = ["MonitoringAccount1"]
+          streams      = ["Microsoft-PrometheusMetrics"]
+        }
+      ]
+      dataSources = {
+        prometheusForwarder = [
+          {
+            name               = "PrometheusDataSource"
+            streams            = ["Microsoft-PrometheusMetrics"]
+            labelIncludeFilter = {}
+          }
+        ]
+      }
+      destinations = {
+        monitoringAccounts = [
+          {
+            accountResourceId = azapi_resource.prometheus.id
+            name              = "MonitoringAccount1"
+          }
+        ]
+      }
+    }
+  })
+}
+
+resource "azapi_resource" "dataCollectionRuleAssociation" {
+  schema_validation_enabled = false
+  type                      = "Microsoft.Insights/dataCollectionRuleAssociations@2021-09-01-preview"
+  name                      = "${local.prefix}-prom-dcra"
+  parent_id                 = azurerm_kubernetes_cluster.stamp.id
+  location                  = azurerm_resource_group.stamp.location
+
+  body = jsonencode({
+    properties = {
+      dataCollectionRuleId = jsondecode(data.azapi_resource.prometheus.output).properties.defaultIngestionSettings.dataCollectionRuleResourceId
+    }
+  })
+}

--- a/src/infra/workload/releaseunit/modules/stamp/prometheus.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/prometheus.tf
@@ -28,7 +28,7 @@ resource "azapi_resource" "dataCollectionRule" {
       destinations = {
         monitoringAccounts = [
           {
-            accountResourceId = azapi_resource.prometheus.id
+            accountResourceId = data.azapi_resource.prometheus.id
             name              = "MonitoringAccount1"
           }
         ]

--- a/src/infra/workload/releaseunit/modules/stamp/prometheus.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/prometheus.tf
@@ -2,8 +2,8 @@ resource "azapi_resource" "dataCollectionRule" {
   schema_validation_enabled = false
 
   type      = "Microsoft.Insights/dataCollectionRules@2021-09-01-preview"
-  name      = "MSPROM-${azurerm_kubernetes_cluster.stamp.name}-${azurerm_kubernetes_cluster.stamp.location}"
-  parent_id = azurerm_kubernetes_cluster.stamp.id
+  name      = "MSPROM-SUK-${azurerm_kubernetes_cluster.stamp.name}-${azurerm_kubernetes_cluster.stamp.location}"
+  parent_id = azurerm_resource_group.stamp.id
   location  = azurerm_resource_group.stamp.location
 
   body = jsonencode({
@@ -34,6 +34,18 @@ resource "azapi_resource" "dataCollectionRule" {
         ]
       }
     }
+  })
+}
+
+resource "azapi_resource" "dataCollectionEndpoint" {
+  type      = "Microsoft.Insights/dataCollectionEndpoints@2021-09-01-preview"
+  name      = "MSPROM-SUK-${azurerm_kubernetes_cluster.stamp.name}-${azurerm_kubernetes_cluster.stamp.location}"
+  parent_id = azurerm_resource_group.stamp.id
+  location  = azurerm_resource_group.stamp.location
+
+  body = jsonencode({
+    kind       = "Linux"
+    properties = {}
   })
 }
 

--- a/src/infra/workload/releaseunit/modules/stamp/prometheus.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/prometheus.tf
@@ -2,7 +2,7 @@ resource "azapi_resource" "dataCollectionRule" {
   schema_validation_enabled = false
 
   type      = "Microsoft.Insights/dataCollectionRules@2021-09-01-preview"
-  name      = "MSPROM-SUK-${azurerm_kubernetes_cluster.stamp.name}"
+  name      = "MSProm-SUK-${azurerm_kubernetes_cluster.stamp.name}"
   parent_id = azurerm_resource_group.stamp.id
   location  = azurerm_resource_group.stamp.location
 
@@ -39,7 +39,7 @@ resource "azapi_resource" "dataCollectionRule" {
 
 resource "azapi_resource" "dataCollectionEndpoint" {
   type      = "Microsoft.Insights/dataCollectionEndpoints@2021-09-01-preview"
-  name      = "MSPROM-SUK-${azurerm_kubernetes_cluster.stamp.name}"
+  name      = "MSProm-SUK-${azurerm_kubernetes_cluster.stamp.name}"
   parent_id = azurerm_resource_group.stamp.id
   location  = azurerm_resource_group.stamp.location
 
@@ -57,6 +57,7 @@ resource "azapi_resource" "dataCollectionRuleAssociation" {
   location                  = azurerm_resource_group.stamp.location
 
   body = jsonencode({
+    scope = azurerm_kubernetes_cluster.stamp.id
     properties = {
       dataCollectionRuleId = jsondecode(data.azapi_resource.prometheus.output).properties.defaultIngestionSettings.dataCollectionRuleResourceId
     }

--- a/src/infra/workload/releaseunit/modules/stamp/prometheus.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/prometheus.tf
@@ -2,7 +2,7 @@ resource "azapi_resource" "dataCollectionRule" {
   schema_validation_enabled = false
 
   type      = "Microsoft.Insights/dataCollectionRules@2021-09-01-preview"
-  name      = "MSPROM-SUK-${azurerm_kubernetes_cluster.stamp.name}-${azurerm_kubernetes_cluster.stamp.location}"
+  name      = "MSPROM-SUK-${azurerm_kubernetes_cluster.stamp.name}"
   parent_id = azurerm_resource_group.stamp.id
   location  = azurerm_resource_group.stamp.location
 
@@ -39,7 +39,7 @@ resource "azapi_resource" "dataCollectionRule" {
 
 resource "azapi_resource" "dataCollectionEndpoint" {
   type      = "Microsoft.Insights/dataCollectionEndpoints@2021-09-01-preview"
-  name      = "MSPROM-SUK-${azurerm_kubernetes_cluster.stamp.name}-${azurerm_kubernetes_cluster.stamp.location}"
+  name      = "MSPROM-SUK-${azurerm_kubernetes_cluster.stamp.name}"
   parent_id = azurerm_resource_group.stamp.id
   location  = azurerm_resource_group.stamp.location
 

--- a/src/infra/workload/releaseunit/modules/stamp/prometheus.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/prometheus.tf
@@ -9,7 +9,7 @@ resource "azapi_resource" "dataCollectionRule" {
   body = jsonencode({
     kind = "Linux"
     properties = {
-      dataCollectionEndpointId = jsondecode(data.azapi_resource.prometheus.output).properties.defaultIngestionSettings.dataCollectionEndpointResourceId
+      dataCollectionEndpointId = azapi_resource.dataCollectionEndpoint.id
       dataFlows = [
         {
           destinations = ["MonitoringAccount1"]

--- a/src/infra/workload/releaseunit/modules/stamp/prometheus.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/prometheus.tf
@@ -52,14 +52,14 @@ resource "azapi_resource" "dataCollectionEndpoint" {
 resource "azapi_resource" "dataCollectionRuleAssociation" {
   schema_validation_enabled = false
   type                      = "Microsoft.Insights/dataCollectionRuleAssociations@2021-09-01-preview"
-  name                      = "${local.prefix}-prom-dcra"
+  name                      = "MSProm-SUK-${azurerm_kubernetes_cluster.stamp.name}"
   parent_id                 = azurerm_kubernetes_cluster.stamp.id
-  location                  = azurerm_resource_group.stamp.location
+  #location                  = azurerm_resource_group.stamp.location
 
   body = jsonencode({
     scope = azurerm_kubernetes_cluster.stamp.id
     properties = {
-      dataCollectionRuleId = jsondecode(data.azapi_resource.prometheus.output).properties.defaultIngestionSettings.dataCollectionRuleResourceId
+      dataCollectionRuleId = azapi_resource.dataCollectionRule.id
     }
   })
 }

--- a/src/testing/loadtest-azure/infra/main.tf
+++ b/src/testing/loadtest-azure/infra/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.34.0"
+      version = "3.37.0"
     }
     azapi = {
       source  = "azure/azapi"

--- a/src/testing/loadtest-locust/infra/main.tf
+++ b/src/testing/loadtest-locust/infra/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.34.0"
+      version = "3.37.0"
     }
   }
 

--- a/src/testing/userload-generator/infra/main.tf
+++ b/src/testing/userload-generator/infra/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.34.0"
+      version = "3.37.0"
     }
   }
 


### PR DESCRIPTION
This PR contains a first draft how Managed Prometheus could be leveraged in Azure Mission-Critical. 

- The Azure Monitor workspace (Managed Prometheus) instance is getting deployed into the monitoring resource group, as part of the global infrastructure deployment. It is not sharing the lifecycle of the stamps.

  <img width="738" alt="image" src="https://user-images.githubusercontent.com/17407022/209127071-2c2620ae-97c4-421a-8a83-dfd48233c50d.png">

  <img width="878" alt="image" src="https://user-images.githubusercontent.com/17407022/209127154-9ce75d84-9dc8-4947-82ad-bcd55fc094b1.png">

  https://github.com/Azure/Mission-Critical-Online/blob/908d2784bf85bb7aff067a756ef76d3a861fb957/src/infra/workload/globalresources/modules/stamp_monitoring/prometheus.tf#L1-L8

- As part of the stamp deployment we're deploying `dataCollectionRules`, `dataCollectionEndpoints` and a `dataCollectionRuleAssociation`.

  https://github.com/Azure/Mission-Critical-Online/blob/908d2784bf85bb7aff067a756ef76d3a861fb957/src/infra/workload/releaseunit/modules/stamp/prometheus.tf#L1-L38

  https://github.com/Azure/Mission-Critical-Online/blob/908d2784bf85bb7aff067a756ef76d3a861fb957/src/infra/workload/releaseunit/modules/stamp/prometheus.tf#L40-L50

  https://github.com/Azure/Mission-Critical-Online/blob/908d2784bf85bb7aff067a756ef76d3a861fb957/src/infra/workload/releaseunit/modules/stamp/prometheus.tf#L52-L65

 
These deployments are all done via AzAPI due to the current lack of support in Terraform's azurerm provider.

The AKS cluster is configured to enable metrics:

https://github.com/Azure/Mission-Critical-Online/blob/908d2784bf85bb7aff067a756ef76d3a861fb957/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf#L13