### PR TITLE
Enable azure_auth for Grafana (supported in Grafana 9.x)

### DIFF
--- a/src/infra/monitoring/grafana/config/grafana.ini
+++ b/src/infra/monitoring/grafana/config/grafana.ini
@@ -343,6 +343,9 @@ default_theme = light
 ; hidden_users =
 
 [auth]
+# Azure specific configuration
+azure_auth_enabled = true
+
 # Login cookie name
 ;login_cookie_name = grafana_session
 

--- a/src/infra/workload/globalresources/modules/stamp_monitoring/log_analytics.tf
+++ b/src/infra/workload/globalresources/modules/stamp_monitoring/log_analytics.tf
@@ -1,6 +1,6 @@
 # Adding a LogAnalytics Workspace for AKS and Container Insights
 resource "azurerm_log_analytics_workspace" "stamp" {
-  name                = "${local.prefix}-#-log"
+  name                = "${local.prefix}-${local.location_short}-log"
   location            = var.location
   resource_group_name = var.resource_group_name
   sku                 = "PerGB2018"

--- a/src/infra/workload/globalresources/modules/stamp_monitoring/log_analytics.tf
+++ b/src/infra/workload/globalresources/modules/stamp_monitoring/log_analytics.tf
@@ -1,6 +1,6 @@
 # Adding a LogAnalytics Workspace for AKS and Container Insights
 resource "azurerm_log_analytics_workspace" "stamp" {
-  name                = "${local.prefix}-${local.location_short}-log"
+  name                = "${local.prefix}-#-log"
   location            = var.location
   resource_group_name = var.resource_group_name
   sku                 = "PerGB2018"


### PR DESCRIPTION
Needed to use the existing Grafana deployment to query Managed Prometheus data.

https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/prometheus-grafana#create-prometheus-data-source-1