### PR TITLE
Change INT region to `westeurope`

### DIFF
--- a/.ado/pipelines/config/variables-values-int.yaml
+++ b/.ado/pipelines/config/variables-values-int.yaml
@@ -9,7 +9,7 @@ variables:
 # The first value in 'stampLocations' is the primary region used for global services.
 # IMPORTANT! Changing the primary region (first value) is a BREAKING change and will destroy CosmosDB and Front Door.
 - name: 'stampLocations'
-  value: '["swedencentral", "uksouth"]' # Check which regions are valid. There is a list in /src/infra/README.md
+  value: '["westeurope", "uksouth"]' # Check which regions are valid. There is a list in /src/infra/README.md
 
 - name: 'stampLocationsGrafana'
   value: '["eastus"]' # Check which regions are valid. There is a list in /src/infra/README.md


### PR DESCRIPTION
`Standard_DSv3` series VMs are not allowed in `swedencentral` in our new subscription. Switching to `westeurope`.