### PR TITLE
Update components and workload identity

### DIFF
--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -5,19 +5,19 @@ variables:
   value: 'foundational-online'
 
 - name: 'terraformVersion'    # Terraform Version
-  value: '1.3.5'
+  value: '1.3.7'
 - name: 'kubernetesVersion'   # kubernetes version used for aks clusters
   value: '1.24.6'
 - name: 'helmVersion'         # helm package manager version
-  value: 'v3.10.2'
+  value: 'v3.11.0'
 - name: 'ingressNginxVersion' # nginx ingress controller helm chart version
-  value: '4.2.5'
+  value: '4.4.2'
 - name: 'certManagerVersion'  # cert-manager helm chart version
-  value: 'v1.9.1'
+  value: 'v1.10.2'
 - name: 'dotnetSdkVersion'    # dotnet sdk version
-  value: '6.0.400'
+  value: '6.0.405'
 - name: 'chaosMeshVersion'    #  chaos-mesh chart version
-  value: '2.3.1'
+  value: '2.5.1'
 - name: 'uiAppNodeVersion'    # nodejs version for the UI app
   value: '18.x'
 - name: 'testsNodeVersion'    # nodejs version used for smoketests / playwright

--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -7,7 +7,7 @@ variables:
 - name: 'terraformVersion'    # Terraform Version
   value: '1.3.7'
 - name: 'kubernetesVersion'   # kubernetes version used for aks clusters
-  value: '1.24.6'
+  value: '1.25.4'
 - name: 'helmVersion'         # helm package manager version
   value: 'v3.11.0'
 - name: 'ingressNginxVersion' # nginx ingress controller helm chart version

--- a/src/app/charts/backgroundprocessor/templates/deployment.yaml
+++ b/src/app/charts/backgroundprocessor/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         app: {{ .Chart.Name }}
-        azure.workload.identity/use: true
+        azure.workload.identity/use: "true"
     spec:
       serviceAccountName: {{ .Chart.Name }}-identity
       containers:

--- a/src/app/charts/backgroundprocessor/templates/deployment.yaml
+++ b/src/app/charts/backgroundprocessor/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       labels:
         app: {{ .Chart.Name }}
+        azure.workload.identity/use: true
     spec:
       serviceAccountName: {{ .Chart.Name }}-identity
       containers:

--- a/src/app/charts/catalogservice/templates/deployment.yaml
+++ b/src/app/charts/catalogservice/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         app: {{ .Chart.Name }}
-        azure.workload.identity/use: true
+        azure.workload.identity/use: "true"
     spec:
       serviceAccountName: {{ .Chart.Name }}-identity
       containers:

--- a/src/app/charts/catalogservice/templates/deployment.yaml
+++ b/src/app/charts/catalogservice/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       labels:
         app: {{ .Chart.Name }}
+        azure.workload.identity/use: true
     spec:
       serviceAccountName: {{ .Chart.Name }}-identity
       containers:

--- a/src/app/charts/healthservice/templates/deployment.yaml
+++ b/src/app/charts/healthservice/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         app: {{ .Chart.Name }}
-        azure.workload.identity/use: true
+        azure.workload.identity/use: "true"
     spec:
       serviceAccountName: {{ .Chart.Name }}-identity
       containers:

--- a/src/app/charts/healthservice/templates/deployment.yaml
+++ b/src/app/charts/healthservice/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       labels:
         app: {{ .Chart.Name }}
+        azure.workload.identity/use: true
     spec:
       serviceAccountName: {{ .Chart.Name }}-identity
       containers:


### PR DESCRIPTION
This PR updates the workload identity implementation based on the following email:

> Our internal monitoring detected that your AKS clusters are configured with workload identity. For applications using workload identity, it's required to add the 'azure.workload.identity/use: "true"' label in the pod labels in AKS to move the workload identity to a 'Fail Close' scenario in the v2023.1.29 release. The change before general availability provides a consistent and reliable behavior for pods that need to use workload identity. 

It also contains some updates for components used:

* https://github.com/hashicorp/terraform/releases/tag/v1.3.7
* https://github.com/helm/helm/releases/tag/v3.11.0
* https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.4.2
* https://github.com/chaos-mesh/chaos-mesh/releases/tag/v2.5.1
* https://github.com/cert-manager/cert-manager/releases/tag/v1.10.2

This was tested in e2e, here: https://dev.azure.com/Mission-Critical/Online/_build/results?buildId=2617&view=results