### PR TITLE
Move Load Balancer to new annotation

### DIFF
--- a/.ado/pipelines/templates/jobs-deploy-configuration.yaml
+++ b/.ado/pipelines/templates/jobs-deploy-configuration.yaml
@@ -50,7 +50,7 @@ jobs:
           helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx `
                        --namespace $(ingressNamespace) --create-namespace `
                        --values src/config/ingress-nginx/values.helm.yaml `
-                       --set controller.service.loadBalancerIP="$aksIngressIp" `
+                       --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-ipv4"="$aksIngressIp" `
                        --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-resource-group"="$aksClusterResourceGroup" `
                        --version "$(ingressNginxVersion)" `
                        --timeout 15m0s `


### PR DESCRIPTION
Old way to specify LB IP is deprecated https://learn.microsoft.com/en-us/azure/aks/load-balancer-standard#specify-the-load-balancer-ip-address

Works in e2e
![image](https://user-images.githubusercontent.com/11445087/228794391-0497a4f0-5563-4c7e-a702-bb2b08bc2fd2.png)

![image](https://user-images.githubusercontent.com/11445087/228794349-b9a2a723-a4f9-4c07-8ecf-01c2bdd0b97e.png)
