### PR TITLE
Drop `retention_policy` from `azurerm_monitor_diagnostic_setting` blocks to address #1018

### DIFF
--- a/src/infra/monitoring/grafana/terraform/globalresources/la-wpspace-config.tf
+++ b/src/infra/monitoring/grafana/terraform/globalresources/la-wpspace-config.tf
@@ -11,11 +11,6 @@ resource "azurerm_monitor_diagnostic_setting" "diag_settings_afd" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -26,11 +21,6 @@ resource "azurerm_monitor_diagnostic_setting" "diag_settings_afd" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }
@@ -49,11 +39,6 @@ resource "azurerm_monitor_diagnostic_setting" "acr" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -64,11 +49,6 @@ resource "azurerm_monitor_diagnostic_setting" "acr" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }

--- a/src/infra/monitoring/grafana/terraform/stamps/la-wspace-config.tf
+++ b/src/infra/monitoring/grafana/terraform/stamps/la-wspace-config.tf
@@ -13,11 +13,6 @@ resource "azurerm_monitor_diagnostic_setting" "appservice" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -27,11 +22,6 @@ resource "azurerm_monitor_diagnostic_setting" "appservice" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }
@@ -49,11 +39,6 @@ resource "azurerm_monitor_diagnostic_setting" "pgprimary" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -64,11 +49,6 @@ resource "azurerm_monitor_diagnostic_setting" "pgprimary" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }
@@ -86,11 +66,6 @@ resource "azurerm_monitor_diagnostic_setting" "pgreplica" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -101,11 +76,6 @@ resource "azurerm_monitor_diagnostic_setting" "pgreplica" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }
@@ -124,11 +94,6 @@ resource "azurerm_monitor_diagnostic_setting" "vnet" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -139,11 +104,6 @@ resource "azurerm_monitor_diagnostic_setting" "vnet" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }
@@ -162,11 +122,6 @@ resource "azurerm_monitor_diagnostic_setting" "asp" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -177,11 +132,6 @@ resource "azurerm_monitor_diagnostic_setting" "asp" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }
@@ -200,11 +150,6 @@ resource "azurerm_monitor_diagnostic_setting" "akv" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -215,11 +160,6 @@ resource "azurerm_monitor_diagnostic_setting" "akv" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }

--- a/src/infra/workload/globalresources/acr.tf
+++ b/src/infra/workload/globalresources/acr.tf
@@ -37,11 +37,6 @@ resource "azurerm_monitor_diagnostic_setting" "acr" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -52,11 +47,6 @@ resource "azurerm_monitor_diagnostic_setting" "acr" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }

--- a/src/infra/workload/globalresources/cosmosdb.tf
+++ b/src/infra/workload/globalresources/cosmosdb.tf
@@ -126,11 +126,6 @@ resource "azurerm_monitor_diagnostic_setting" "cosmosdb" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -141,11 +136,6 @@ resource "azurerm_monitor_diagnostic_setting" "cosmosdb" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }

--- a/src/infra/workload/globalresources/frontdoor.tf
+++ b/src/infra/workload/globalresources/frontdoor.tf
@@ -308,11 +308,6 @@ resource "azurerm_monitor_diagnostic_setting" "frontdoor" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -323,11 +318,6 @@ resource "azurerm_monitor_diagnostic_setting" "frontdoor" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }

--- a/src/infra/workload/globalresources/storage.tf
+++ b/src/infra/workload/globalresources/storage.tf
@@ -45,11 +45,6 @@ resource "azurerm_monitor_diagnostic_setting" "storage_global" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -60,11 +55,6 @@ resource "azurerm_monitor_diagnostic_setting" "storage_global" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }

--- a/src/infra/workload/releaseunit/modules/stamp/eventhub.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/eventhub.tf
@@ -47,11 +47,6 @@ resource "azurerm_monitor_diagnostic_setting" "eventhub" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -62,11 +57,6 @@ resource "azurerm_monitor_diagnostic_setting" "eventhub" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }

--- a/src/infra/workload/releaseunit/modules/stamp/keyvault.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/keyvault.tf
@@ -75,11 +75,6 @@ resource "azurerm_monitor_diagnostic_setting" "kv" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -90,11 +85,6 @@ resource "azurerm_monitor_diagnostic_setting" "kv" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -122,11 +122,6 @@ resource "azurerm_monitor_diagnostic_setting" "aks" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -137,11 +132,6 @@ resource "azurerm_monitor_diagnostic_setting" "aks" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }

--- a/src/infra/workload/releaseunit/modules/stamp/network.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/network.tf
@@ -104,11 +104,6 @@ resource "azurerm_monitor_diagnostic_setting" "vnet" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -119,11 +114,6 @@ resource "azurerm_monitor_diagnostic_setting" "vnet" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }

--- a/src/infra/workload/releaseunit/modules/stamp/storage.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/storage.tf
@@ -82,11 +82,6 @@ resource "azurerm_monitor_diagnostic_setting" "storage_public" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -97,11 +92,6 @@ resource "azurerm_monitor_diagnostic_setting" "storage_public" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }
@@ -121,11 +111,6 @@ resource "azurerm_monitor_diagnostic_setting" "storage_public_blob" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -136,11 +121,6 @@ resource "azurerm_monitor_diagnostic_setting" "storage_public_blob" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }
@@ -163,11 +143,6 @@ resource "azurerm_monitor_diagnostic_setting" "storage_private" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -178,11 +153,6 @@ resource "azurerm_monitor_diagnostic_setting" "storage_private" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }
@@ -202,11 +172,6 @@ resource "azurerm_monitor_diagnostic_setting" "storage_private_blob" {
 
     content {
       category = entry.value
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 
@@ -217,11 +182,6 @@ resource "azurerm_monitor_diagnostic_setting" "storage_private_blob" {
     content {
       category = entry.value
       enabled  = true
-
-      retention_policy {
-        enabled = true
-        days    = 30
-      }
     }
   }
 }


### PR DESCRIPTION
This PR drops the `retention_poliy` block from `azurerm_monitor_diagnostic_setting` to address issue #1018.

Successfully tested in E2E: https://dev.azure.com/Mission-Critical/Online/_build/results?buildId=3013&view=results 