### PR TITLE
Option to disable diagnostic settings

### DIFF
--- a/src/infra/workload/releaseunit/modules/stamp/eventhub.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/eventhub.tf
@@ -37,6 +37,8 @@ data "azurerm_monitor_diagnostic_categories" "eventhub" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "eventhub" {
+  count = var.disable_diagnostics ? 0 : 1 # disable diagnostics if var.disable_diagnostics=true
+  
   name                       = "eventhubladiagnostics"
   target_resource_id         = azurerm_eventhub_namespace.stamp.id
   log_analytics_workspace_id = data.azurerm_log_analytics_workspace.stamp.id

--- a/src/infra/workload/releaseunit/modules/stamp/keyvault.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/keyvault.tf
@@ -65,6 +65,8 @@ data "azurerm_monitor_diagnostic_categories" "kv" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "kv" {
+  count = var.disable_diagnostics ? 0 : 1 # disable diagnostics if var.disable_diagnostics=true
+  
   name                       = "kvladiagnostics"
   target_resource_id         = azurerm_key_vault.stamp.id
   log_analytics_workspace_id = data.azurerm_log_analytics_workspace.stamp.id

--- a/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/kubernetes.tf
@@ -113,6 +113,8 @@ data "azurerm_monitor_diagnostic_categories" "aks" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "aks" {
+  count = var.disable_diagnostics ? 0 : 1 # disable diagnostics if var.disable_diagnostics=true
+
   name                       = "aksladiagnostics"
   target_resource_id         = azurerm_kubernetes_cluster.stamp.id
   log_analytics_workspace_id = data.azurerm_log_analytics_workspace.stamp.id

--- a/src/infra/workload/releaseunit/modules/stamp/network.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/network.tf
@@ -94,6 +94,8 @@ data "azurerm_monitor_diagnostic_categories" "vnet" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "vnet" {
+  count = var.disable_diagnostics ? 0 : 1 # disable diagnostics if var.disable_diagnostics=true
+  
   name                       = "vnetladiagnostics"
   target_resource_id         = azurerm_virtual_network.stamp.id
   log_analytics_workspace_id = data.azurerm_log_analytics_workspace.stamp.id

--- a/src/infra/workload/releaseunit/modules/stamp/storage.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/storage.tf
@@ -72,6 +72,8 @@ data "azurerm_monitor_diagnostic_categories" "storage_public" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "storage_public" {
+  count = var.disable_diagnostics ? 0 : 1 # disable diagnostics if var.disable_diagnostics=true
+  
   name                       = "storageladiagnostics"
   target_resource_id         = azurerm_storage_account.public.id
   log_analytics_workspace_id = data.azurerm_log_analytics_workspace.stamp.id
@@ -101,6 +103,8 @@ data "azurerm_monitor_diagnostic_categories" "storage_public_blob" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "storage_public_blob" {
+  count = var.disable_diagnostics ? 0 : 1 # disable diagnostics if var.disable_diagnostics=true
+
   name                       = "storageblobladiagnostics"
   target_resource_id         = "${azurerm_storage_account.public.id}/blobServices/default/"
   log_analytics_workspace_id = data.azurerm_log_analytics_workspace.stamp.id
@@ -133,6 +137,8 @@ data "azurerm_monitor_diagnostic_categories" "storage_private" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "storage_private" {
+  count = var.disable_diagnostics ? 0 : 1 # disable diagnostics if var.disable_diagnostics=true
+
   name                       = "storageladiagnostics"
   target_resource_id         = azurerm_storage_account.private.id
   log_analytics_workspace_id = data.azurerm_log_analytics_workspace.stamp.id
@@ -162,6 +168,8 @@ data "azurerm_monitor_diagnostic_categories" "storage_private_blob" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "storage_private_blob" {
+  count = var.disable_diagnostics ? 0 : 1 # disable diagnostics if var.disable_diagnostics=true
+
   name                       = "storageblobladiagnostics"
   target_resource_id         = "${azurerm_storage_account.private.id}/blobServices/default/"
   log_analytics_workspace_id = data.azurerm_log_analytics_workspace.stamp.id

--- a/src/infra/workload/releaseunit/modules/stamp/variables.tf
+++ b/src/infra/workload/releaseunit/modules/stamp/variables.tf
@@ -122,6 +122,12 @@ variable "api_key" {
   sensitive   = true
 }
 
+variable "disable_diagnostics" {
+  description = "Disable diagnostics settings (cost savings)"
+  type        = bool
+  default     = false
+}
+
 variable "ai_adaptive_sampling" {
   description = "Enable adaptive sampling in Application Insights. Setting this to false means that 100% of the telemetry will be collected."
   type        = bool

--- a/src/infra/workload/releaseunit/stamp.tf
+++ b/src/infra/workload/releaseunit/stamp.tf
@@ -55,4 +55,6 @@ module "stamp" {
   alerts_enabled       = var.alerts_enabled
   api_key              = random_password.api_key.result
   ai_adaptive_sampling = var.ai_adaptive_sampling
+
+  disable_diagnostics = var.disable_diagnostics
 }

--- a/src/infra/workload/releaseunit/variables-e2e.tfvars
+++ b/src/infra/workload/releaseunit/variables-e2e.tfvars
@@ -13,3 +13,5 @@ event_hub_thoughput_units     = 1
 event_hub_enable_auto_inflate = false
 
 ai_adaptive_sampling = true # enables/disables adaptive sampling for Application Insights; disabled means that 100 % of telemetry will be collected
+
+disable_diagnostics = true

--- a/src/infra/workload/releaseunit/variables.tf
+++ b/src/infra/workload/releaseunit/variables.tf
@@ -38,6 +38,12 @@ variable "contact_email" {
   default     = "OVERWRITE@noreply.com"
 }
 
+variable "disable_diagnostics" {
+  description = "Disable all diagnostic settings (cost saving)"
+  type        = bool
+  default     = false
+}
+
 variable "alerts_enabled" {
   description = "Enable alerts?"
   type        = bool


### PR DESCRIPTION
This (draft) PR contains an option to opt-out from enabling all diagnostic settings in E2E.

ToDo
* [x] disable diagnostic settings for regional resources
* [ ] extend to cover global resources
* [ ] add a checkbox to the run pipeline wizard