### PR TITLE
Fix workflows

### DIFF
--- a/.github/workflows/resetBranch.yml
+++ b/.github/workflows/resetBranch.yml
@@ -1,4 +1,4 @@
-name: Reset component-updates branch
+name: 'Reset component-updates branch'
 
 on:
   workflow_dispatch:
@@ -8,21 +8,24 @@ env:
 
 jobs:
   resetBranch:
+    name: 'Reset component-updates branch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       
-      - name: Checkout component-updates
+      - name: 'Checkout component-updates'
         run: |
           git checkout -b component-updates
 
-      - name: Reset branch
+      - name: 'Reset branch'
         run: |
           git reset --hard origin/main
       
-      - name: Push
+      - name: 'Push'
         run: |
           git push --set-upstream origin component-updates --force

--- a/.github/workflows/updateDependabot.yml
+++ b/.github/workflows/updateDependabot.yml
@@ -11,8 +11,8 @@ jobs:
     name: 'Update Dependabot'
     runs-on: ubuntu-latest
     permissions:
-      actions: write
-      contents: read
+      actions: read
+      contents: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/updateDependabot.yml
+++ b/.github/workflows/updateDependabot.yml
@@ -8,21 +8,25 @@ env:
 
 jobs:
   UpdateDependabot:
+    name: 'Update Dependabot'
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Create a working branch
+      - name: 'Create a working branch'
         run: |
           git checkout -b ${{ env.BRANCH_NAME }}
 
-      - name: Update Dependabot
+      - name: 'Update Dependabot'
         shell: pwsh
         run: |
           ./.github/scripts/update-dependabot.ps1 -targetBranch component-updates -outputFile ./.github/dependabot.yml
 
-      - name: Push files to repo
+      - name: 'Push files to repo'
         shell: pwsh
         run: |
 

--- a/.github/workflows/updateDependabot.yml
+++ b/.github/workflows/updateDependabot.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
+      pull-requests: write
       contents: write
 
     steps:


### PR DESCRIPTION
Still not creating a pull request due to org-wide policies, but it's now at least creating a new branch that can then be used to manually create a pull request.

https://eng.ms/docs/more/github-inside-microsoft/repos/actions
https://eng.ms/docs/more/github-inside-microsoft/policies/actions
https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#permissions